### PR TITLE
Set CONDA_BUILD_SYSROOT

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-ci-setup
-  version: 1.0.0
+  version: 1.1.0
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,6 +12,16 @@ export PYTHONUNBUFFERED=1
 #   way is working well enough.
 export MACOSX_DEPLOYMENT_TARGET="10.9"
 
+export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
+
+if [ -f "${CONDA_BUILD_SYSROOT}" ]
+then
+    echo "Found CONDA_BUILD_SYSROOT: ${CONDA_BUILD_SYSROOT}"
+else
+    echo "Missing CONDA_BUILD_SYSROOT: ${CONDA_BUILD_SYSROOT}"
+    exit 1
+fi
+
 conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-smithy/issues/678

Configures `CONDA_BUILD_SYSROOT` dynamically on Travis CI as part of the build setup. Does this as we need to check for the active macOS SDK with `xcode-select -p`.

cc @isuruf