### PR TITLE
Use newer anaconda-client API

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,9 +28,8 @@ install:
     - cmd: rmdir C:\cygwin /s /q
 
     # Add path, activate `conda` and update conda.
-    # Around November of 2017, Appveyor changed Miniconda3-x64 from an old 3.4 install to a
-    #     symlink to the current version.
-    - cmd: call C:\Miniconda3-x64\Scripts\activate.bat
+    - cmd: call C:\Miniconda36-x64\Scripts\activate.bat
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
@@ -39,9 +38,6 @@ install:
     - cmd: conda.exe config --remove channels defaults
     - cmd: conda.exe config --add channels defaults
     - cmd: conda.exe config --add channels conda-forge
-
-    # workaround for https://github.com/conda/conda/issues/6057
-    - cmd: conda.exe update --yes --quiet conda
 
     # Configure the VM.
     - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-ci-setup
-  version: 1.2.0
+  version: 1.2.1
 
 build:
   number: 0

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 
-from binstar_client.utils import get_binstar
+from binstar_client.utils import get_server_api
 import binstar_client.errors
 import conda.config
 from conda.api import get_index
@@ -104,7 +104,7 @@ def main():
     args = parser.parse_args()
     recipe_dir, owner, channel = args.recipe_dir, args.owner, args.channel
 
-    cli = get_binstar(argparse.Namespace(token=token, site=None))
+    cli = get_server_api(token=token)
     metas = conda_build.api.render(recipe_dir, variant_config_files=args.variant_config_files)
     for meta, _, _ in metas:
         fnames = conda_build.api.get_output_file_paths(meta)

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -13,7 +13,7 @@ import tempfile
 from binstar_client.utils import get_server_api
 import binstar_client.errors
 from conda_build.conda_interface import subdir as conda_subdir
-from conda.api import get_index
+from conda_build.conda_interface import get_index
 import conda_build.api
 
 

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -12,7 +12,7 @@ import tempfile
 
 from binstar_client.utils import get_server_api
 import binstar_client.errors
-import conda.config
+from conda_build.conda_interface import subdir as conda_subdir
 from conda.api import get_index
 import conda_build.api
 
@@ -81,7 +81,7 @@ def distribution_exists_on_channel(binstar_cli, meta, fname, owner, channel='mai
 
     try:
         on_channel = (distributions_on_channel[fname]['subdir'] ==
-                      conda.config.subdir)
+                      conda_subdir)
     except KeyError:
         on_channel = False
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/9

Seems `get_binstar` has been deprecated for a while (and recently removed). This switches us over to the newer, preferred `get_server_api`.

xref: https://github.com/Anaconda-Platform/anaconda-client/issues/463
xref: https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/94 (backport)