### PR TITLE
Windows use conda.exe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-ci-setup
-  version: 1.2.1
+  version: 1.2.2
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -5,14 +5,14 @@ set CPU_COUNT=2
 
 set PYTHONUNBUFFERED=1
 
-conda config --set show_channel_urls true
-conda config --set auto_update_conda false
-conda config --set add_pip_as_python_dependency false
+conda.exe config --set show_channel_urls true
+conda.exe config --set auto_update_conda false
+conda.exe config --set add_pip_as_python_dependency false
 
 call setup_x64
 
 :: Set the conda-build working directory to a smaller path
 set "CONDA_BLD_PATH=C:\\bld\\"
 
-conda info
-conda config --get
+conda.exe info
+conda.exe config --get


### PR DESCRIPTION
Use `conda.exe` on Windows. Basically forward porting PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/96 ).

cc @isuruf @msarahan