### PR TITLE
Update `DTSDKName` to match our macOS SDK

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -19,6 +19,7 @@ if [[ ! -d ${CONDA_BUILD_SYSROOT} || "$OSX_FORCE_SDK_DOWNLOAD" == "1" ]]; then
     tar -xf MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz -C "$(dirname "$CONDA_BUILD_SYSROOT")"
     # set minimum sdk version to our target
     plutil -replace MinimumSDKVersion -string ${MACOSX_DEPLOYMENT_TARGET} $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
+    plutil -replace DTSDKName -string macosx${MACOSX_DEPLOYMENT_TARGET}internal $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
 fi
 
 if [ -d "${CONDA_BUILD_SYSROOT}" ]


### PR DESCRIPTION
The `DTSDKName` was getting fixed by our old `sed` strategy along with the `MinimumSDKVersion`. We fix the `MinimumSDKVersion` already as this vital. It's less clear if the `DTSDKName` needs to be accurately reflected. Though it could show up in applications' `Info.plist`, so we might as well have it accurately reflected just in case. After this change there does not appear to be any more references to the OS SDK version other than the intended one.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
