### PR TITLE
Fix pull request failures

### DIFF
--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -92,7 +92,7 @@ def upload_or_check(recipe_dir, owner, channel, variant):
 
     # Azure's tokens are filled when in PR and not empty as for the other cis
     # In pr they will have a value like '$(secret-name)'
-    if token.startswith('$('):
+    if token and token.startswith('$('):
         token = None
 
     cli = get_server_api(token=token)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "2.1.2" %}
+{% set version = "2.1.3" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Since #44, pull requests builds are currently failing on platforms other than azure due to `BINSTAR_TOKEN` not being set. Example from [this](https://circleci.com/gh/conda-forge/uproot-feedstock/45) build:

```python
+ upload_package /home/conda/feedstock_root /home/conda/recipe_root /home/conda/feedstock_root/.ci_support/linux_python3.7.yaml
Traceback (most recent call last):
  File "/opt/conda/bin/upload_package", line 11, in <module>
    sys.exit(upload_package())
  File "/opt/conda/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/opt/conda/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/conda_forge_ci_setup/build_utils.py", line 82, in upload_package
    upload_or_check(recipe_root, owner, channel, [config_file])
  File "/opt/conda/lib/python3.6/site-packages/conda_forge_ci_setup/upload_or_check_non_existence.py", line 95, in upload_or_check
    if token.startswith('$('):
AttributeError: 'NoneType' object has no attribute 'startswith'
```