### PR TITLE
TravisCI: CPU_COUNT is Two (2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "2.5.3" %}
+{% set version = "2.5.4" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -11,10 +11,11 @@ export "CONDA_BLD_PATH=${FEEDSTOCK_ROOT}/build_artifacts"
 set +u
 
 # Don't set the number of CPUs for some CI systems
-if [ "${CI}" = "drone" ] || [ "${CI}" = "travis" ]; then
+if [ "${CI}" = "drone" ]; then
     export CPU_COUNT=
 else
     # 2 cores available on CircleCI workers: https://discuss.circleci.com/t/what-runs-on-the-node-container-by-default/1443
+    # 2 cores available on TravisCI workers: https://docs.travis-ci.com/user/reference/overview/
     # CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149
     export CPU_COUNT=2
 fi


### PR DESCRIPTION
The CPU_COUNT on TravisCI should be two (2) and leads to killed compiler processes otherwise for some builds.
See: https://docs.travis-ci.com/user/reference/overview/

Addresses: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/53#issuecomment-571796823

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
