### PR TITLE
ENH If possible, don't modify the config.yaml file on Linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "2.8.1" %}
+{% set version = "2.8.2" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -27,8 +27,8 @@ fi
 
 
 if [ ! -z "$CONFIG" ]; then
-    echo "" >> ${CI_SUPPORT}/${CONFIG}.yaml
     if [ ! -z "$CI" ]; then
+        echo "" >> ${CI_SUPPORT}/${CONFIG}.yaml
         echo "CI:" >> ${CI_SUPPORT}/${CONFIG}.yaml
         echo "- ${CI}" >> ${CI_SUPPORT}/${CONFIG}.yaml
         echo "" >> ${CI_SUPPORT}/${CONFIG}.yaml


### PR DESCRIPTION
When running Docker builds locally on Linux, the default behavior appends a blank line to the YAML configuration file needlessly, potentially polluting Git checkouts.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This isn't worth building a new package for, so I'm not bumping the build number or anything.