### PR TITLE
ENH fix bugs in cfep-13 validation, simpler

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -32,7 +32,7 @@ jobs:
       source activate base
       echo "Configuring conda."
 
-      conda install -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build pip
+      conda install -c conda-forge --quiet --yes conda-forge-ci-setup=3 conda-build pip
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
       conda uninstall --quiet --yes --force conda-forge-ci-setup
       pip install --no-deps recipe/.
@@ -45,7 +45,7 @@ jobs:
     env: {
       OSX_FORCE_SDK_DOWNLOAD: "1"
     }
-    displayName: 'Configure conda, conda-build, and add conda-forge-ci-setup=2'
+    displayName: 'Configure conda, conda-build, and add conda-forge-ci-setup=3'
 
   - script: |
       echo "Mangling homebrew from Azure to avoid conflicts."
@@ -72,7 +72,7 @@ jobs:
   - script: |
       source activate base
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
+      upload_package "conda-forge-ci-setup-feedstock" ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,7 +60,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
@@ -106,7 +106,7 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         call activate base
-        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package "conda-forge-ci-setup-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build pip -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
 
 conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps ${RECIPE_ROOT}/.
@@ -37,7 +37,7 @@ conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package "conda-forge-ci-setup-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,8 +52,10 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"

--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -35,7 +35,7 @@ def request_copy(feedstock, dists, channel):
         dist = _unix_dist_path(path)
         checksums[dist] = _compute_md5sum(path)
 
-    if "FEEDSTOCK_TOKEN" not in os.environ:
+    if "FEEDSTOCK_TOKEN" not in os.environ or os.environ["FEEDSTOCK_TOKEN"] is None:
         print(
             "ERROR you must have defined a FEEDSTOCK_TOKEN in order to "
             "perform output copies to the production channels!"

--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -13,8 +13,8 @@ VALIDATION_ENDPOINT = "https://conda-forge.herokuapp.com"
 STAGING = "cf-staging"
 
 
-def _unix_path(path):
-    return "/".join(os.path.split(path))
+def _unix_dist_path(path):
+    return "/".join(path.split(os.sep)[-2:])
 
 
 def _compute_md5sum(pth):
@@ -32,7 +32,7 @@ def _compute_md5sum(pth):
 def request_copy(feedstock, dists, channel):
     checksums = {}
     for path in dists:
-        dist = _unix_path(os.path.relpath(conda_build.config.croot, path))
+        dist = _unix_dist_path(path)
         checksums[dist] = _compute_md5sum(path)
 
     if "FEEDSTOCK_TOKEN" not in os.environ:
@@ -84,7 +84,7 @@ def main(feedstock_name):
             for p in os.listdir(os.path.join(conda_build.config.croot, conda_build.config.subdir))  # noqa
         ])
     built_distributions = [
-        _unix_path(path) for path in paths if path.endswith('.tar.bz2')
+        _unix_dist_path(path) for path in paths if path.endswith('.tar.bz2')
     ]
 
     print("validating outputs:\n%s" % pprint.pformat(built_distributions))

--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -2,19 +2,19 @@ import os
 import sys
 import hashlib
 import json
-import functools
+import pprint
 
 import conda_build
+import conda_build.config
 import requests
 import click
 
-try:
-    from ruamel_yaml import safe_load
-except ImportError:
-    from yaml import safe_load
-
 VALIDATION_ENDPOINT = "https://conda-forge.herokuapp.com"
 STAGING = "cf-staging"
+
+
+def _unix_path(path):
+    return "/".join(os.path.split(path))
 
 
 def _compute_md5sum(pth):
@@ -29,18 +29,18 @@ def _compute_md5sum(pth):
     return h.hexdigest()
 
 
-def request_copy(dists, channel):
+def request_copy(feedstock, dists, channel):
     checksums = {}
-    for dist in dists:
-        checksums[dist] = _compute_md5sum(dist)
-
-    feedstock = os.path.basename(os.getcwd())
+    for path in dists:
+        dist = _unix_path(os.path.relpath(conda_build.config.croot, path))
+        checksums[dist] = _compute_md5sum(path)
 
     if "FEEDSTOCK_TOKEN" not in os.environ:
         print(
             "ERROR you must have defined a FEEDSTOCK_TOKEN in order to "
             "perform output copies to the production channels!"
         )
+        return False
 
     headers = {"FEEDSTOCK_TOKEN": os.environ["FEEDSTOCK_TOKEN"]}
     json_data = {
@@ -69,25 +69,10 @@ def request_copy(dists, channel):
     return r.status_code == 200
 
 
-@functools.lru_cache(maxsize=1)
-def _should_validate():
-    if os.path.exists("conda-forge.yml"):
-        with open("conda-forge.yml", "r") as fp:
-            cfg = safe_load(fp)
-
-        return cfg.get("conda_forge_output_validation", False)
-    else:
-        return False
-
-
 @click.command()
-def main():
+@click.argument("feedstock_name", type=str)
+def main(feedstock_name):
     """Validate the feedstock outputs."""
-
-    if not _should_validate():
-        sys.exit(0)
-
-    feedstock = os.path.basename(os.getcwd())
 
     paths = (
         [
@@ -98,12 +83,16 @@ def main():
             os.path.join(conda_build.config.subdir, p)
             for p in os.listdir(os.path.join(conda_build.config.croot, conda_build.config.subdir))  # noqa
         ])
-    built_distributions = [path for path in paths if path.endswith('.tar.bz2')]
+    built_distributions = [
+        _unix_path(path) for path in paths if path.endswith('.tar.bz2')
+    ]
+
+    print("validating outputs:\n%s" % pprint.pformat(built_distributions))
 
     r = requests.post(
         "%s/feedstock-outputs/validate" % VALIDATION_ENDPOINT,
         json={
-            "feedstock": feedstock,
+            "feedstock": feedstock_name,
             "outputs": built_distributions,
         },
     )

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -79,7 +79,8 @@ def upload(token_fn, path, owner, channels):
 
 
 def delete_dist(token_fn, path, owner, channels):
-    path = os.path.relpath(conda_build.config.croot, path)
+    parts = path.split(os.sep)
+    path = os.path.join(parts[-2], parts[-1])
     _, name, ver, _ = split_pkg(path)
     subprocess.check_call(
         [

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -85,7 +85,8 @@ def delete_dist(token_fn, path, owner, channels):
     subprocess.check_call(
         [
             'anaconda', '--quiet', '-t', token_fn,
-            'remove', '-f', "%s/%s/%s/%s" % (owner, name, ver, path),
+            'remove', '-f', '"%s/%s/%s/%s/%s"' % (
+                owner, name, ver, parts[-2], parts[-1]),
         ],
         env=os.environ
     )

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -158,12 +158,17 @@ def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=Fal
                         ):
                             upload(token_fn, path, owner, channel)
                             break
+                        else:
+                            print(
+                                "Distribution {} already exists on {}. "
+                                "Waiting another {} seconds to "
+                                "try again.".format(path, owner, (i+1) * 15))
                     else:
                         print(
                             "WARNING: Distribution {} already existed in "
-                            "{} for a while.".format(path, owner)
+                            "{} for a while. Deleting and "
+                            "re-uploading.".format(path, owner)
                         )
-                        print("         Deleting and re-uploading.")
                         delete_dist(token_fn, path, owner, channel)
                         upload(token_fn, path, owner, channel)
 
@@ -211,7 +216,7 @@ def retry_upload_or_check(
         except Exception as e:
             timeout = i ** 2
             print(
-                "Failed to upload due to {}.  Trying again in {} seconds".format(
+                "Failed to upload due to {}. Trying again in {} seconds".format(
                     e, timeout))
             time.sleep(timeout)
     raise TimeoutError("Did not manage to upload package.  Failing.")

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -16,7 +16,7 @@ from conda_build.conda_interface import get_index
 import conda_build.api
 import conda_build.config
 
-from .feedstock_outputs import _should_validate, request_copy
+from .feedstock_outputs import request_copy
 
 
 def split_pkg(pkg):
@@ -112,7 +112,7 @@ def distribution_exists_on_channel(binstar_cli, meta, fname, owner, channel='mai
     return on_channel
 
 
-def upload_or_check(recipe_dir, owner, channel, variant):
+def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=False):
     token = os.environ.get('BINSTAR_TOKEN')
 
     # Azure's tokens are filled when in PR and not empty as for the other cis
@@ -149,28 +149,38 @@ def upload_or_check(recipe_dir, owner, channel, variant):
     # for all uploads
     if token:
         with get_temp_token(cli.token) as token_fn:
-            if _should_validate():
+            if validate:
                 for name, version, path in built_distributions:
                     for i in range(0, 15):
-                        sleep(i*15)
-                        if not built_distribution_already_exists(cli, name, version, path, owner):
+                        time.sleep(i*15)
+                        if not built_distribution_already_exists(
+                            cli, name, version, path, owner
+                        ):
                             upload(token_fn, path, owner, channel)
                             break
                     else:
-                        print("WARNING: Distribution {} already existed in {} for a while.".format(path, owner))
+                        print(
+                            "WARNING: Distribution {} already existed in "
+                            "{} for a while.".format(path, owner)
+                        )
                         print("         Deleting and re-uploading.")
                         delete_dist(token_fn, path, owner, channel)
                         upload(token_fn, path, owner, channel)
 
-                return request_copy([
-                    os.path.relpath(conda_build.config.croot, path)
-                    for _, _, path in built_distributions], channel)
+                return request_copy(
+                    feedstock,
+                    [path for _, _, path in built_distributions],
+                    channel,
+                )
             else:
                 for name, version, path in built_distributions:
-                    if not built_distribution_already_exists(cli, name, version, path, owner):
+                    if not built_distribution_already_exists(
+                        cli, name, version, path, owner
+                    ):
                         upload(token_fn, path, owner, channel)
                     else:
-                        print('Distribution {} already exists for {}'.format(path, owner))
+                        print(
+                            'Distribution {} already exists for {}'.format(path, owner))
                 return True
     else:
         for name, version, path in built_distributions:
@@ -183,12 +193,16 @@ def upload_or_check(recipe_dir, owner, channel, variant):
         return False
 
 
-def retry_upload_or_check(recipe_dir, owner, channel, variant):
+def retry_upload_or_check(
+    feedstock, recipe_dir, owner, channel, variant, validate=False
+):
     # perform a backoff in case we fail.  THis should limit the failures from
     # issues with the Anaconda api
     for i in range(1, 10):
         try:
-            res = upload_or_check(recipe_dir, owner, channel, variant)
+            res = upload_or_check(
+                feedstock, recipe_dir, owner, channel, variant, validate=validate
+            )
             return res
         except Exception as e:
             timeout = i ** 2
@@ -214,7 +228,7 @@ def main(recipe_dir, owner, channel, variant):
     Upload or check consistency of a built version of a conda recipe with binstar.
     Note: The existence of the BINSTAR_TOKEN environment variable determines
     whether the upload should actually take place."""
-    return retry_upload_or_check(recipe_dir, owner, channel, variant)
+    return retry_upload_or_check(None, recipe_dir, owner, channel, variant)
 
 
 if __name__ == '__main__':

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -85,7 +85,7 @@ def delete_dist(token_fn, path, owner, channels):
     subprocess.check_call(
         [
             'anaconda', '--quiet', '-t', token_fn,
-            'remove', '-f', '"%s/%s/%s/%s/%s"' % (
+            'remove', '-f', '%s/%s/%s/%s/%s' % (
                 owner, name, ver, parts[-2], parts[-1]),
         ],
         env=os.environ

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -162,7 +162,7 @@ def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=Fal
                             print(
                                 "Distribution {} already exists on {}. "
                                 "Waiting another {} seconds to "
-                                "try again.".format(path, owner, (i+1) * 15))
+                                "try uploading again.".format(path, owner, (i+1) * 15))
                     else:
                         print(
                             "WARNING: Distribution {} already existed in "

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -151,7 +151,7 @@ def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=Fal
         with get_temp_token(cli.token) as token_fn:
             if validate:
                 for name, version, path in built_distributions:
-                    for i in range(0, 15):
+                    for i in range(0, 5):
                         time.sleep(i*15)
                         if not built_distribution_already_exists(
                             cli, name, version, path, owner
@@ -167,11 +167,15 @@ def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=Fal
                         delete_dist(token_fn, path, owner, channel)
                         upload(token_fn, path, owner, channel)
 
-                return request_copy(
+                if not request_copy(
                     feedstock,
                     [path for _, _, path in built_distributions],
                     channel,
-                )
+                ):
+                    raise RuntimeError(
+                        "copy from staging to production channel failed")
+                else:
+                    return True
             else:
                 for name, version, path in built_distributions:
                     if not built_distribution_already_exists(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.0.1" %}
+{% set version = "3.0.2" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
It turns out that the CI services all use different names for the directory where the feedstock is checked out and that it is easier to simply have smithy compute the feedstock name rather than have this script guess it on the fly. Similarly, smithy is already checking the conda-forge.yml to see if validation should happen, so I moved all of that logic turning validation on into smithy and not here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
