### PR TITLE
ENH unbreak the API and use staging token

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,60 +20,10 @@ jobs:
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      echo "Fast Finish"
-      
-
-  - bash: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    displayName: Add conda to PATH
-
-  - script: |
-      source activate base
-      echo "Configuring conda."
-
-      conda install -c conda-forge --quiet --yes conda-forge-ci-setup=3 conda-build pip
-      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-      conda uninstall --quiet --yes --force conda-forge-ci-setup
-      pip install --no-deps recipe/.
-
-      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
-      # Overriding global run_conda_forge_build_setup_osx with local copy.
-      source recipe/run_conda_forge_build_setup_osx
-
-    env: {
-      OSX_FORCE_SDK_DOWNLOAD: "1"
-    }
-    displayName: 'Configure conda, conda-build, and add conda-forge-ci-setup=3'
-
-  - script: |
-      echo "Mangling homebrew from Azure to avoid conflicts."
-      source activate base
-      /usr/bin/sudo mangle_homebrew
-      /usr/bin/sudo -k
-    displayName: Mangle homebrew
-
-  - script: |
-      source activate base
-      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Mangle compiler
-
-  - script: |
-      source activate base
-      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Generate build number clobber file
-
-  - script: |
-      source activate base
-      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-    displayName: Build recipe
-
-  - script: |
-      source activate base
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package "conda-forge-ci-setup-feedstock" ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Upload package
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,7 +60,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2 pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -106,7 +106,7 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         call activate base
-        upload_package "conda-forge-ci-setup-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package  .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -37,7 +37,7 @@ conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package "conda-forge-ci-setup-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build pip -c conda-forge
 
 conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps ${RECIPE_ROOT}/.

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=2 and conda-build."
+conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+
+
+conda uninstall --quiet --yes --force conda-forge-ci-setup
+pip install --no-deps recipe/.
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+# Overriding global run_conda_forge_build_setup_osx with local copy.
+source recipe/run_conda_forge_build_setup_osx
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package  ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=2 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes conda-forge-ci-setup=2 conda-build pip
 
 
 conda uninstall --quiet --yes --force conda-forge-ci-setup

--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -111,12 +111,15 @@ def setup_conda_rc(feedstock_root, recipe_root, config_file):
 
 
 @click.command()
-@click.argument("feedstock_name", type=str)
 @arg_feedstock_root
 @arg_recipe_root
 @arg_config_file
 @click.option("--validate", is_flag=True)
-def upload_package(feedstock_name, feedstock_root, recipe_root, config_file, validate):
+@click.option("--feedstock-name", type=str, default=None)
+def upload_package(feedstock_root, recipe_root, config_file, validate, feedstock_name):
+    if feedstock_name is None and validate:
+        raise RuntimeError("You must supply the --feedstock-name option if validating!")
+
     specific_config = safe_load(open(config_file))
     if "channel_targets" in specific_config:
         channels = [c.strip().split(" ") for c in specific_config["channel_targets"]]

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -117,8 +117,10 @@ def distribution_exists_on_channel(binstar_cli, meta, fname, owner, channel='mai
 def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=False):
     if validate and "STAGING_BINSTAR_TOKEN" in os.environ:
         token = os.environ["STAGING_BINSTAR_TOKEN"]
+        print("Using STAGING_BINSTAR_TOKEN for anaconda.org uploads to %s." % owner)
     else:
         token = os.environ.get('BINSTAR_TOKEN')
+        print("Using BINSTAR_TOKEN for anaconda.org uploads to %s." % owner)
 
     # Azure's tokens are filled when in PR and not empty as for the other cis
     # In pr they will have a value like '$(secret-name)'

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -115,7 +115,10 @@ def distribution_exists_on_channel(binstar_cli, meta, fname, owner, channel='mai
 
 
 def upload_or_check(feedstock, recipe_dir, owner, channel, variant, validate=False):
-    token = os.environ.get('BINSTAR_TOKEN')
+    if validate and "STAGING_BINSTAR_TOKEN" in os.environ:
+        token = os.environ["STAGING_BINSTAR_TOKEN"]
+    else:
+        token = os.environ.get('BINSTAR_TOKEN')
 
     # Azure's tokens are filled when in PR and not empty as for the other cis
     # In pr they will have a value like '$(secret-name)'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.0.2" %}
+{% set version = "3.0.3" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This PR unbreaks the API with v2 and uses the staging token if it is there. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
