### PR TITLE
Add missing libcuda.so on 9.2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,46 @@ jobs:
         CONFIG: linux_aarch64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-aarch64
+      linux_cuda_compiler_version10.0python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version10.0python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
+      linux_cuda_compiler_version10.0python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version10.0python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
+      linux_cuda_compiler_version10.1python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version10.1python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
+      linux_cuda_compiler_version10.1python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version10.1python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
+      linux_cuda_compiler_version10.2python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version10.2python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
+      linux_cuda_compiler_version10.2python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version10.2python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
+      linux_cuda_compiler_version9.2python3.6.____cpython:
+        CONFIG: linux_cuda_compiler_version9.2python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
+      linux_cuda_compiler_version9.2python3.7.____cpython:
+        CONFIG: linux_cuda_compiler_version9.2python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
+      linux_cuda_compiler_versionNonepython3.6.____cpython:
+        CONFIG: linux_cuda_compiler_versionNonepython3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_cuda_compiler_versionNonepython3.7.____cpython:
+        CONFIG: linux_cuda_compiler_versionNonepython3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_ppc64le_python3.6.____cpython:
         CONFIG: linux_ppc64le_python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -24,14 +64,6 @@ jobs:
         CONFIG: linux_ppc64le_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_python3.6.____cpython:
-        CONFIG: linux_python3.6.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.7.____cpython:
-        CONFIG: linux_python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
     maxParallel: 8
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_cuda_compiler_version10.0python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0python3.6.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.0'
+docker_image:
+- condaforge/linux-anvil-cuda:10.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.0python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0python3.7.____cpython.yaml
@@ -2,11 +2,18 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.0'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:10.0
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1python3.6.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.1'
+docker_image:
+- condaforge/linux-anvil-cuda:10.1
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1python3.7.____cpython.yaml
@@ -2,11 +2,18 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.1'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:10.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.7.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.2python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.6.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.2'
+docker_image:
+- condaforge/linux-anvil-cuda:10.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.2python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.7.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.2'
+docker_image:
+- condaforge/linux-anvil-cuda:10.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '9.2'
+docker_image:
+- condaforge/linux-anvil-cuda:9.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '9.2'
+docker_image:
+- condaforge/linux-anvil-cuda:9.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_versionNonepython3.6.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_versionNonepython3.6.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- None
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_versionNonepython3.7.____cpython.yaml
+++ b/.ci_support/linux_cuda_compiler_versionNonepython3.7.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- None
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/README.md
+++ b/README.md
@@ -43,6 +43,76 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_cuda_compiler_version10.0python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.0python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.0python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.1python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.1python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.2python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.2python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version9.2python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version9.2python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version9.2python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_versionNonepython3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_versionNonepython3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_versionNonepython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_versionNonepython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
@@ -54,20 +124,6 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_python3.6.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_python3.7.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.0.9" %}
+{% set version = "3.0.10" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,9 @@ requirements:
     - git     # [unix]
 
 test:
+  # ensure that all variants of cuda_compiler_version are tested
+  requires:                                    # [linux and cuda_compiler_version not in (undefined, "None")]
+    - cudatoolkit {{ cuda_compiler_version }}  # [linux and cuda_compiler_version not in (undefined, "None")]
   commands:
     - if not exist "%PREFIX%\\Scripts\\run_conda_forge_build_setup.bat" exit 1    # [win]
     - test -f "${PREFIX}/bin/run_conda_forge_build_setup"                         # [unix]

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -25,6 +25,26 @@ if [[ "$CONFIG" == *_pypy* ]]; then
   conda config --set channel_priority strict
 fi
 
+# the upstream image nvidia/cuda:9.2-devel-centos6 (on which linux-anvil-cuda:9.2 is based)
+# does not contain libcuda.so; it should be installed in ${CUDA_HOME}/compat-${CUDA_VER},
+# however cuda-compat-${CUDA_VER}.x86_64.rpm is only packaged for 10.x; we abuse
+# cuda-compat-10.0 for this, since the actual dependency containing libcuda for 9.2
+# (xorg-x11-drv-nvidia-libs) pulls in a huge amount of dependencies;
+# this cannot be fixed in the conda-forge linux-anvil-cuda images for licensing reasons
+# (cannot add cuda-package in our image layers), so we add it here for CI purposes only.
+if [[ ! -z "$CUDA_HOME" && -d /usr/local/cuda-9.2 ]]; then
+  # note: $CUDA_HOME is just a symlink to /usr/local/cuda-${CUDA_VER}
+
+  # register cuda-repo with installer, cf.
+  # https://developer.download.nvidia.com/compute/cuda/repos/rhel6/x86_64/
+  curl -O https://developer.download.nvidia.com/compute/cuda/repos/rhel6/x86_64/cuda-repo-rhel6-9.2.148-1.x86_64.rpm
+  sudo yum localinstall -y cuda-repo-*.rpm
+  rm cuda-repo-*.rpm
+  # install latest cuda-compat-10-0
+  sudo yum install -y cuda-compat-10-0.x86_64 ;
+  # note: this path is added to ldconfig in linux-anvil-cuda:9.2
+  if [[ ! -f "/usr/local/cuda-10.0/compat/libcuda.so" ]]; then exit 1; fi
+fi
 
 if [ ! -z "$CONFIG" ]; then
     if [ ! -z "$CI" ]; then


### PR DESCRIPTION
This is complementary to https://github.com/conda-forge/docker-images/pull/135; aiming at unblocking https://github.com/conda-forge/pyarrow-feedstock/pull/101 & https://github.com/conda-forge/faiss-split-feedstock/pull/1.