### PR TITLE
Remove GHC from Azure images

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -100,13 +100,13 @@ jobs:
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
         call activate base
-        validate_recipe_outputs "conda-forge-ci-setup-feedstock"
+        validate_recipe_outputs "conda-forge-ci-setup"
       displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         call activate base
-        upload_package --validate --feedstock-name="conda-forge-ci-setup-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="conda-forge-ci-setup" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 
 build_artifacts
-.vscode/

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,10 +34,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "conda-forge-ci-setup-feedstock"
+validate_recipe_outputs "conda-forge-ci-setup"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="conda-forge-ci-setup-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="conda-forge-ci-setup" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -50,9 +50,9 @@ set -e
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "conda-forge-ci-setup-feedstock"
+validate_recipe_outputs "conda-forge-ci-setup"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="conda-forge-ci-setup-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="conda-forge-ci-setup" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.0.14" %}
+{% set version = "3.0.15" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -20,6 +20,11 @@ else
     export CPU_COUNT=2
 fi
 
+# Remove GHC install on Azure
+if [ "${CI}" = "azure" ]; then
+    rm -rf /opt/ghc
+fi
+
 # Need strict priority for pypy as defaults is not fixed
 if [[ "$CONFIG" == *_pypy* ]]; then
   conda config --set channel_priority strict


### PR DESCRIPTION
Removes `/opt/ghc` from the Azure Linux image to free up some space needed by builds that need more room.

cc @isuruf @h-vetinari @pearu

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/omniscidb-feedstock/issues/5
xref: https://github.com/conda-forge/faiss-split-feedstock/pull/5