### PR TITLE
Use the latest SDK For macOS if specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 
 build_artifacts
-.vscode/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.0.14" %}
+{% set version = "3.0.15" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -6,6 +6,10 @@ export CPU_COUNT=2
 
 export PYTHONUNBUFFERED=1
 
+# Typically, we want to build with the lastest SDK, even though the deployment target may be older.
+# See: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html#//apple_ref/doc/uid/10000163i-CH1-SW1
+export MACOSX_SDK_VERSION=${MACOSX_SDK_VERSION:-10.15}
+
 if [ -f .ci_support/${CONFIG}.yaml ]; then
    export MACOSX_DEPLOYMENT_TARGET=$(cat .ci_support/${CONFIG}.yaml | shyaml get-value MACOSX_DEPLOYMENT_TARGET.0 10.9)
 fi
@@ -15,15 +19,15 @@ fi
 # which should only be recipes still using conda-build 2.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.9}
 
-export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
+export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_SDK_VERSION}.sdk"
 
 if [[ ! -d ${CONDA_BUILD_SYSROOT} || "$OSX_FORCE_SDK_DOWNLOAD" == "1" ]]; then
-    echo "Downloading ${MACOSX_DEPLOYMENT_TARGET} sdk"
-    curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz
-    tar -xf MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk.tar.xz -C "$(dirname "$CONDA_BUILD_SYSROOT")"
+    echo "Downloading ${MACOSX_SDK_VERSION} sdk"
+    curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX${MACOSX_SDK_VERSION}.sdk.tar.xz
+    tar -xf MacOSX${MACOSX_SDK_VERSION}.sdk.tar.xz -C "$(dirname "$CONDA_BUILD_SYSROOT")"
     # set minimum sdk version to our target
-    plutil -replace MinimumSDKVersion -string ${MACOSX_DEPLOYMENT_TARGET} $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
-    plutil -replace DTSDKName -string macosx${MACOSX_DEPLOYMENT_TARGET}internal $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
+    plutil -replace MinimumSDKVersion -string ${MACOSX_SDK_VERSION} $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
+    plutil -replace DTSDKName -string macosx${MACOSX_SDK_VERSION}internal $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
 fi
 
 if [ -d "${CONDA_BUILD_SYSROOT}" ]

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -15,6 +15,10 @@ fi
 # which should only be recipes still using conda-build 2.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.9}
 
+if [ -f .ci_support/${CONFIG}.yaml ]; then
+   export WITH_LATEST_OSX_SDK=$(cat .ci_support/${CONFIG}.yaml | shyaml get-value WITH_LATEST_OSX_SDK.0 0)
+fi
+
 if [[ "$WITH_LATEST_OSX_SDK" == "1" ]]; then
     # Typically, we want to build with the lastest SDK, even though the deployment target may be older.
     # See: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html#//apple_ref/doc/uid/10000163i-CH1-SW1

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -6,10 +6,6 @@ export CPU_COUNT=2
 
 export PYTHONUNBUFFERED=1
 
-# Typically, we want to build with the lastest SDK, even though the deployment target may be older.
-# See: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html#//apple_ref/doc/uid/10000163i-CH1-SW1
-export MACOSX_SDK_VERSION=${MACOSX_SDK_VERSION:-10.15}
-
 if [ -f .ci_support/${CONFIG}.yaml ]; then
    export MACOSX_DEPLOYMENT_TARGET=$(cat .ci_support/${CONFIG}.yaml | shyaml get-value MACOSX_DEPLOYMENT_TARGET.0 10.9)
 fi
@@ -18,6 +14,14 @@ fi
 # The default here will only be used when that is undefined,
 # which should only be recipes still using conda-build 2.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.9}
+
+if [[ "$WITH_LATEST_OSX_SDK" == "1" ]]; then
+    # Typically, we want to build with the lastest SDK, even though the deployment target may be older.
+    # See: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html#//apple_ref/doc/uid/10000163i-CH1-SW1
+    export MACOSX_SDK_VERSION=10.15
+else
+    export MACOSX_SDK_VERSION=$MACOSX_DEPLOYMENT_TARGET
+fi
 
 export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_SDK_VERSION}.sdk"
 


### PR DESCRIPTION
Some projects require newer versions of the OSX SDK to be used, even
though the deployment target may be older. [Qt is one of those cases](https://doc.qt.io/qt-5/macos.html),
and using an older version of the OSX SDK to build Python, for instance,
[is causing some bugs when used with PySide2](https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/67).

Since Apple supports having an older deployment target while building
with a new SDK, default to the new SDK.

I am cautiously submitting this PR, without testing it, and knowing that
this might break some CI. But I am submitting it as a possible solution
to fix #67, which is causing problems for one of our projects.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes: #67