### PR TITLE
Allow CPU_COUNT to be set externally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 
 build_artifacts
-.vscode/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.0.14" %}
+{% set version = "3.0.15" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -17,7 +17,7 @@ else
     # 2 cores available on CircleCI workers: https://discuss.circleci.com/t/what-runs-on-the-node-container-by-default/1443
     # 2 cores available on TravisCI workers: https://docs.travis-ci.com/user/reference/overview/
     # CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149
-    export CPU_COUNT=2
+    export CPU_COUNT="${CPU_COUNT:-2}"
 fi
 
 # Need strict priority for pypy as defaults is not fixed

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -2,7 +2,7 @@
 
 # 2 core available on Travis CI OS X workers: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
 # CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149
-export CPU_COUNT=2
+export CPU_COUNT="${CPU_COUNT:-2}"
 
 export PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Allows the CPU_COUNT variable to be set manually as suggested in https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/53#issuecomment-484327013.