### PR TITLE
Add CONDA_OVERRIDE_CUDA for current CUDA version.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.7.3" %}
+{% set version = "3.8.0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.7.2" %}
+{% set version = "3.7.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -53,7 +53,7 @@ if [[ ! -z "$CUDA_HOME" && -d /usr/local/cuda-9.2 ]]; then
 fi
 
 # Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
-CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yml | shyaml get-value cuda_compiler_version.0)"
+CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yml | shyaml get-value cuda_compiler_version None)"
 if [[ "$CUDA_VERSION" == "None" ]]; then
     CUDA_VERSION=""
 fi

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -50,6 +50,10 @@ if [[ ! -z "$CUDA_HOME" && -d /usr/local/cuda-9.2 ]]; then
   sudo yum install -y cuda-compat-10-0.$(uname -m) ;
   # note: this path is added to ldconfig in linux-anvil-cuda:9.2
   if [[ ! -f "/usr/local/cuda-10.0/compat/libcuda.so" ]]; then exit 1; fi
+
+  # Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
+  CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yml | shyaml get-value cuda_compiler_version.0 None)"
+  echo "export CONDA_OVERRIDE_CUDA='${CUDA_VERSION}'" > "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 fi
 
 if [ ! -z "$CONFIG" ]; then

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -52,13 +52,6 @@ if [[ ! -z "$CUDA_HOME" && -d /usr/local/cuda-9.2 ]]; then
   if [[ ! -f "/usr/local/cuda-10.0/compat/libcuda.so" ]]; then exit 1; fi
 fi
 
-# Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
-CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value cuda_compiler_version.0 None)"
-if [[ "$CUDA_VERSION" == "None" ]]; then
-    CUDA_VERSION=""
-fi
-export CONDA_OVERRIDE_CUDA="${CUDA_VERSION}"
-
 if [ ! -z "$CONFIG" ]; then
     if [ ! -z "$CI" ]; then
         echo "" >> ${CI_SUPPORT}/${CONFIG}.yaml
@@ -77,7 +70,13 @@ if [ -n "${CPU_COUNT}" ]; then
     echo "export CPU_COUNT='${CPU_COUNT}'"                  >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 fi
 echo "export PYTHONUNBUFFERED='${PYTHONUNBUFFERED}'"    >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
-echo "export CONDA_OVERRIDE_CUDA='${CONDA_OVERRIDE_CUDA}'" >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
+
+# Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
+CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value cuda_compiler_version.0 None)"
+if [[ "$CUDA_VERSION" != "None" ]]; then
+    export CONDA_OVERRIDE_CUDA="${CUDA_VERSION}"
+    echo "export CONDA_OVERRIDE_CUDA='${CONDA_OVERRIDE_CUDA}'" >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
+fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/cross_compile_support.sh

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -57,6 +57,7 @@ CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value cuda_compile
 if [[ "$CUDA_VERSION" == "None" ]]; then
     CUDA_VERSION=""
 fi
+export CONDA_OVERRIDE_CUDA="${CUDA_VERSION}"
 echo "export CONDA_OVERRIDE_CUDA='${CUDA_VERSION}'" > "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 
 if [ ! -z "$CONFIG" ]; then

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -50,11 +50,14 @@ if [[ ! -z "$CUDA_HOME" && -d /usr/local/cuda-9.2 ]]; then
   sudo yum install -y cuda-compat-10-0.$(uname -m) ;
   # note: this path is added to ldconfig in linux-anvil-cuda:9.2
   if [[ ! -f "/usr/local/cuda-10.0/compat/libcuda.so" ]]; then exit 1; fi
-
-  # Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
-  CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yml | shyaml get-value cuda_compiler_version.0 None)"
-  echo "export CONDA_OVERRIDE_CUDA='${CUDA_VERSION}'" > "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 fi
+
+# Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
+CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yml | shyaml get-value cuda_compiler_version.0)"
+if [[ "$CUDA_VERSION" == "None" ]]; then
+    CUDA_VERSION=""
+fi
+echo "export CONDA_OVERRIDE_CUDA='${CUDA_VERSION}'" > "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 
 if [ ! -z "$CONFIG" ]; then
     if [ ! -z "$CI" ]; then

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -58,7 +58,6 @@ if [[ "$CUDA_VERSION" == "None" ]]; then
     CUDA_VERSION=""
 fi
 export CONDA_OVERRIDE_CUDA="${CUDA_VERSION}"
-echo "export CONDA_OVERRIDE_CUDA='${CUDA_VERSION}'" > "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 
 if [ ! -z "$CONFIG" ]; then
     if [ ! -z "$CI" ]; then
@@ -78,6 +77,7 @@ if [ -n "${CPU_COUNT}" ]; then
     echo "export CPU_COUNT='${CPU_COUNT}'"                  >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 fi
 echo "export PYTHONUNBUFFERED='${PYTHONUNBUFFERED}'"    >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
+echo "export CONDA_OVERRIDE_CUDA='${CONDA_OVERRIDE_CUDA}'" >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${SCRIPT_DIR}/cross_compile_support.sh

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -53,7 +53,7 @@ if [[ ! -z "$CUDA_HOME" && -d /usr/local/cuda-9.2 ]]; then
 fi
 
 # Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
-CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yml | shyaml get-value cuda_compiler_version None)"
+CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value cuda_compiler_version.0 None)"
 if [[ "$CUDA_VERSION" == "None" ]]; then
     CUDA_VERSION=""
 fi

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -70,8 +70,8 @@ if not "%CUDA_VERSION%" == "None" (
     :: We succeeded! Export paths
     set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION%"
     set "PATH=%PATH%;%CUDA_PATH%\bin"
+    set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
 )
-set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
 :: /CUDA
 
 type .ci_support\%CONFIG%.yaml

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -71,6 +71,7 @@ if not "%CUDA_VERSION%" == "None" (
     set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION%"
     set "PATH=%PATH%;%CUDA_PATH%\bin"
 )
+set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
 :: /CUDA
 
 type .ci_support\%CONFIG%.yaml
@@ -84,6 +85,9 @@ echo set "PATH=%PATH%"                            >> "%CONDA_PREFIX%\etc\conda\a
 if not "%CUDA_PATH%" == "" (
     echo set "CUDA_PATH=%CUDA_PATH%"              >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
     echo set "CUDA_HOME=%CUDA_PATH%"              >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
+)
+if not "%CUDA_VERSION%" == "None" (
+    echo set "CONDA_OVERRIDE_CUDA=%CONDA_OVERRIDE_CUDA%" >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
 )
 
 conda.exe info

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -85,6 +85,7 @@ echo set "PATH=%PATH%"                            >> "%CONDA_PREFIX%\etc\conda\a
 if not "%CUDA_PATH%" == "" (
     echo set "CUDA_PATH=%CUDA_PATH%"              >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
     echo set "CUDA_HOME=%CUDA_PATH%"              >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
+    :: Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
     echo set "CONDA_OVERRIDE_CUDA=%CONDA_OVERRIDE_CUDA%" >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -85,8 +85,6 @@ echo set "PATH=%PATH%"                            >> "%CONDA_PREFIX%\etc\conda\a
 if not "%CUDA_PATH%" == "" (
     echo set "CUDA_PATH=%CUDA_PATH%"              >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
     echo set "CUDA_HOME=%CUDA_PATH%"              >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
-)
-if not "%CUDA_VERSION%" == "None" (
     echo set "CONDA_OVERRIDE_CUDA=%CONDA_OVERRIDE_CUDA%" >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
 )
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR adds `CONDA_OVERRIDE_CUDA` as discussed on Gitter. This will enable packages to specify `__cuda` versions as a run dependency.

I was able to test that the `shyaml` logic detects the correct values for `CONDA_OVERRIDE_CUDA`. See also: [conda docs on detected package overrides](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#overriding-detected-packages)).