### PR TITLE
Do not raise an exception if 'defaults' is not in the config

### DIFF
--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -103,7 +103,11 @@ def setup_conda_rc(feedstock_root, recipe_root, config_file):
             update_global_config(feedstock_root)
             channels = _global_config["channels"]["sources"]
 
-        call(["conda", "config", "--remove", "channels", "defaults"])
+        try:
+            call(["conda", "config", "--remove", "channels", "defaults"])
+        except subprocess.CalledProcessError:
+            pass
+
         for c in reversed(channels):
             call(["conda", "config", "--add", "channels", c])
 


### PR DESCRIPTION
This is a proposed fix for the case when `~/.condarc` does not have the `defaults` channel and only has the `conda-forge` one (or any other). The problem was originally observed on the [OSX build](https://dev.azure.com/nsls2forge/nsls2forge/_build/results?buildId=7965&view=logs&j=9c5ef928-2cd6-52e5-dbe6-9d173a7d951b&t=20c71c51-4b27-578b-485d-06ade2de1d00&l=298) for https://github.com/nsls-ii-forge/hunter-feedstock/pull/8:
```py
Setting up the condarc and mangling the compiler.
+ setup_conda_rc ./ ./recipe ./.ci_support/osx_64_python3.7.yaml

CondaKeyError: 'channels': 'defaults' is not in the 'channels' key of the config file

Traceback (most recent call last):
  File "/Users/runner/miniforge3/bin/setup_conda_rc", line 11, in <module>
    sys.exit(setup_conda_rc())
  File "/Users/runner/miniforge3/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/runner/miniforge3/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/runner/miniforge3/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/runner/miniforge3/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/runner/miniforge3/lib/python3.8/site-packages/conda_forge_ci_setup/build_utils.py", line 106, in setup_conda_rc
    call(["conda", "config", "--remove", "channels", "defaults"])
  File "/Users/runner/miniforge3/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['conda', 'config', '--remove', 'channels', 'defaults']' returned non-zero exit status 1.
```
That exception breaks the execution flow, and the channels list is not propagated to the `~/.condarc` file.

For OSX builds the default configuration contains only the `conda-forge` channel, which comes from https://github.com/conda-forge/miniforge/blob/ab5909ba786461b79a8e57c227da51d1e8155e54/Miniforge3/construct.yaml#L12 I believe.

It does not happen on Linux builds as it's done via a different code path: https://github.com/nsls-ii-forge/hunter-feedstock/blob/bb6d2285eecbdc6c358e9a9cff2926515e29124c/.scripts/build_steps.sh#L21-L32. That code block generates the `~/.condarc` file without channels at all, so the step passes. I haven't looked at how it's done for Windows, but I guess the corresponding `.condarc` file does not contain the channel list in it.

### Steps to reproduce:
- Create a file with the following contents (similar to the OSX case):
  ```bash
  $ cat ~/.condarc
  channels:
    - conda-forge
  ```
- Try to remove the `defaults` channel from it (expect a failure with the return code 1):
  ```bash
  $ conda config --remove channels defaults

  CondaKeyError: 'channels': 'defaults' is not in the 'channels' key of the config file

  $ echo $?
  1
  ```
- Create a file with the following contents (similar to the Linux case):
  ```
  $ cat ~/.condarc
  conda-build:
    root-dir: /tmp/build_artifacts
  ```
- Try to remove the `defaults` channel from it (expect a success with the return code 0):
  ```bash
  $ conda config --remove channels defaults
  $ echo $?
  0
  ```

I tested the implemented fix with the locally installed version of `conda-forge-ci-setup`:
```bash
$ cat ~/.condarc
channels:
  - conda-forge
$ setup_conda_rc ./ ./recipe ./.ci_support/osx_64_python3.7.yaml

CondaKeyError: 'channels': 'defaults' is not in the 'channels' key of the config file

$ cat ~/.condarc
channels:
  - nsls2forge
  - defaults
  - conda-forge
show_channel_urls: true
```