### PR TITLE
Don't fail run_conda_forge_build_setup when conda-forge.yml missing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.9.2" %}
+{% set version = "3.9.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -24,7 +24,7 @@ fi
 # - pypy as defaults is not fixed
 # - cos7 as defaults is not fixed
 # but ppl can turn this off
-conda config --set channel_priority $(cat ${FEEDSTOCK_ROOT}/conda-forge.yml | shyaml get-value channel_priority strict)
+conda config --set channel_priority $(cat ${FEEDSTOCK_ROOT}/conda-forge.yml | shyaml get-value channel_priority strict || echo strict)
 
 # the upstream image nvidia/cuda:9.2-devel-centos6 (on which linux-anvil-cuda:9.2 is based)
 # does not contain libcuda.so; it should be installed in ${CUDA_HOME}/compat-${CUDA_VER},

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,7 +12,7 @@ conda config --set add_pip_as_python_dependency false
 
 # Need strict priority for pypy as defaults is not fixed
 # but ppl can turn this off
-conda config --set channel_priority $(cat ./conda-forge.yml | shyaml get-value channel_priority strict)
+conda config --set channel_priority $(cat ./conda-forge.yml | shyaml get-value channel_priority strict || echo strict)
 
 # CONDA_PREFIX might be unset
 export CONDA_PREFIX="${CONDA_PREFIX:-$(conda info --json | jq -r .root_prefix)}"

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,7 +9,7 @@ conda.exe config --set show_channel_urls true
 conda.exe config --set auto_update_conda false
 conda.exe config --set add_pip_as_python_dependency false
 
-type conda-forge.yml | shyaml get-value channel_priority strict > tmpFile
+(type conda-forge.yml | shyaml get-value channel_priority strict || echo strict) > tmpFile
 set /p channel_priority= < tmpFile
 del tmpFile
 conda.exe config --set channel_priority %channel_priority%


### PR DESCRIPTION
The `run_conda_forge_build_setup` scripts read from `conda-forge.yml` to get the `channel_priority`, defaulting to strict if the setting is missing. But if `conda-forge.yml` is missing completely, the script would fail because shyaml does not return the default when there is no YAML to parse at all. This fixes that by ensuring that "strict" is returned in those cases as well.

While `conda-forge.yml` would never normally be missing, if https://github.com/conda-forge/conda-smithy/pull/1469 is merged then it becomes possible to put the feedstock configuration in another file. If that is done, then the existing scripts will fail. With this fix, that change to `conda-smithy` becomes usable, even though it would be impossible to override `channel_priority` (possibilities for doing this could be explored later, if necessary). At any rate, this change doesn't hurt and could provide some extra robustness.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
