### PR TITLE
Fix pagefile sizing; add some echos on windows

### DIFF
--- a/recipe/ExecuteSetPageFileSize.bat
+++ b/recipe/ExecuteSetPageFileSize.bat
@@ -1,6 +1,0 @@
-ECHO Calling: SetPageFileSize.ps1 -MinimumSize %1 -MaximumSize %2 -DiskRoot %3
-SET ThisScriptsDirectory=%~dp0
-SET PowerShellScriptPath=%ThisScriptsDirectory%SetPageFileSize.ps1
-:: assumes this file is colocated with SetPageFileSize.ps1
-:: arguments need to be passed in order
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' -MinimumSize %1 -MaximumSize %2 -DiskRoot %3"

--- a/recipe/ExecuteSetPageFileSize.bat
+++ b/recipe/ExecuteSetPageFileSize.bat
@@ -1,6 +1,6 @@
-ECHO Calling: "SetPageFileSize.ps1 -MinimumSize %1 -MaximumSize %2 -DiskRoot %3"
+ECHO Calling: SetPageFileSize.ps1 -MinimumSize %1 -MaximumSize %2 -DiskRoot %3
 SET ThisScriptsDirectory=%~dp0
 SET PowerShellScriptPath=%ThisScriptsDirectory%SetPageFileSize.ps1
 :: assumes this file is colocated with SetPageFileSize.ps1
-:: arguments need to be passed in order; DiskRoot should be passed with quotes
+:: arguments need to be passed in order
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' -MinimumSize %1 -MaximumSize %2 -DiskRoot %3"

--- a/recipe/ExecuteSetPageFileSize.bat
+++ b/recipe/ExecuteSetPageFileSize.bat
@@ -1,0 +1,6 @@
+ECHO Calling: "SetPageFileSize.ps1 -MinimumSize %1 -MaximumSize %2 -DiskRoot %3"
+SET ThisScriptsDirectory=%~dp0
+SET PowerShellScriptPath=%ThisScriptsDirectory%SetPageFileSize.ps1
+:: assumes this file is colocated with SetPageFileSize.ps1
+:: arguments need to be passed in order; DiskRoot should be passed with quotes
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%PowerShellScriptPath%' -MinimumSize %1 -MaximumSize %2 -DiskRoot %3"

--- a/recipe/SetPageFileSize.ps1
+++ b/recipe/SetPageFileSize.ps1
@@ -7,7 +7,7 @@
   SetPageFileSize.ps1 -MinimumSize 4GB -MaximumSize 8GB -DiskRoot "D:"
 #>
 
-# this file taken 1:1 (with the exception of this comment) from the MIT-licensed
+# this file taken 1:1 (with the exception of this comment & the parameter echo) from the MIT-licensed
 # https://github.com/al-cheb/configure-pagefile-action/blob/916fa29e5d27bd4e8eef3666869afbaaee27d9eb/scripts/SetPageFileSize.ps1
 
 param(

--- a/recipe/SetPageFileSize.ps1
+++ b/recipe/SetPageFileSize.ps1
@@ -192,5 +192,6 @@ namespace Util
 
 Add-Type -TypeDefinition $source
 
+echo Parameters: $minimumSize, $maximumSize, $diskRoot
 # Set SetPageFileSize
 [Util.PageFile]::SetPageFileSize($minimumSize, $maximumSize, $diskRoot)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.10.0" %}
+{% set version = "3.10.1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
     - mkdir -p "${PREFIX}/bin"                                                                                           # [unix]
     - COPY "%RECIPE_DIR%\\run_conda_forge_build_setup_win.bat" "%SCRIPTS%\\run_conda_forge_build_setup.bat"              # [win]
     - COPY "%RECIPE_DIR%\\SetPageFileSize.ps1" "%SCRIPTS%\\SetPageFileSize.ps1"                                          # [win]
+    - COPY "%RECIPE_DIR%\\ExecuteSetPageFileSize.bat" "%SCRIPTS%\\ExecuteSetPageFileSize.bat"                            # [win]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_osx" "${PREFIX}/bin/run_conda_forge_build_setup"                     # [osx]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_linux" "${PREFIX}/bin/run_conda_forge_build_setup"                   # [linux]
     - cp "${RECIPE_DIR}/download_osx_sdk.sh" "${PREFIX}/bin/download_osx_sdk.sh"                                         # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
     - mkdir -p "${PREFIX}/bin"                                                                                           # [unix]
     - COPY "%RECIPE_DIR%\\run_conda_forge_build_setup_win.bat" "%SCRIPTS%\\run_conda_forge_build_setup.bat"              # [win]
     - COPY "%RECIPE_DIR%\\SetPageFileSize.ps1" "%SCRIPTS%\\SetPageFileSize.ps1"                                          # [win]
-    - COPY "%RECIPE_DIR%\\ExecuteSetPageFileSize.bat" "%SCRIPTS%\\ExecuteSetPageFileSize.bat"                            # [win]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_osx" "${PREFIX}/bin/run_conda_forge_build_setup"                     # [osx]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_linux" "${PREFIX}/bin/run_conda_forge_build_setup"                   # [linux]
     - cp "${RECIPE_DIR}/download_osx_sdk.sh" "${PREFIX}/bin/download_osx_sdk.sh"                                         # [unix]

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" '
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" '}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """8GB""" -MaximumSize """8GB""" -DiskRoot """"C:"""" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize ""8GB"" -MaximumSize ""8GB"" -DiskRoot """""C:""""" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -24,10 +24,15 @@ if "%CONDA_BLD_PATH%" == "" (
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
 if "%CI%" == "azure" (
+    :: use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
-        echo Setting pagefile size to 8GB
+        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
         REM this file will be run within %SCRIPTS%, where SetPageFileSize.ps1 is also copied into, see meta.yaml
         call SetPageFileSize.ps1 -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:"
+    )
+    if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
+        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
+        call SetPageFileSize.ps1 -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "C:"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File `"%EntryPointPath%`" -MinimumSize `"8589934592`" -MaximumSize `"8589934592`" -DiskRoot `"C:`" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8589934592"""" -MaximumSize """"8589934592"""" -DiskRoot """"""""C:"""""""" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -24,15 +24,15 @@ if "%CONDA_BLD_PATH%" == "" (
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
 if "%CI%" == "azure" (
-    :: use different drive than CONDA_BLD_PATH-location for pagefile
+    REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        REM this file will be run within %SCRIPTS%, where SetPageFileSize.ps1 is also copied into, see meta.yaml
-        call SetPageFileSize.ps1 -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:"
+        REM this file will be run within %SCRIPTS%, where SetPageFileSize.ps1/ExecuteSetPageFileSize.bat is also copied into, see meta.yaml
+        call ExecuteSetPageFileSize.bat 8GB 8GB "D:"
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        call SetPageFileSize.ps1 -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "C:"
+        call ExecuteSetPageFileSize.bat 8GB 8GB "C:"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" ' -NoNewWindow -PassThru -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8GB"""" -MaximumSize """"8GB"""" -DiskRoot """""C:""""" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" ' -PassThru}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" ' -NoNewWindow -PassThru -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot 'D:'"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot D:"
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot 'C:'"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot C:"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -1,4 +1,3 @@
-@echo on
 
 :: 2 cores available on Appveyor workers: https://www.appveyor.com/docs/build-environment/#build-vm-configurations
 :: CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize ""8GB"" -MaximumSize ""8GB"" -DiskRoot """""C:""""" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8GB"""" / 1 -MaximumSize """"8GB"""" / 1 -DiskRoot """"C:"""" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -25,8 +25,9 @@ if "%CONDA_BLD_PATH%" == "" (
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
 if "%CI%" == "azure" (
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
+        echo Setting pagefile size to 8GB
         REM this file will be run within %SCRIPTS%, where SetPageFileSize.ps1 is also copied into, see meta.yaml
-        call SetPageFileSize.ps1 -MinimumSize 4GB -MaximumSize 8GB -DiskRoot "D:"
+        call SetPageFileSize.ps1 -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -26,18 +26,21 @@ if "%CONDA_BLD_PATH%" == "" (
 :: Both in the recipe and in the final package, this script is co-located with SetPageFileSize.ps1, see meta.yaml
 set ThisScriptsDirectory=%~dp0
 set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
-if "%CI%" == "azure" (
-    REM use different drive than CONDA_BLD_PATH-location for pagefile
-    if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
-        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        REM Inspired by:
-        REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
-        REM Drive-letter needs to be escaped in quotes
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"D:\""
-    )
-    if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
-        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"C:\""
+:: Only run if SET_PAGEFILE is set; EntryPointPath needs to be set before if not using delayed execution.
+if "%SET_PAGEFILE%" NEQ "" (
+    if "%CI%" == "azure" (
+        REM use different drive than CONDA_BLD_PATH-location for pagefile
+        if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
+            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
+            REM Inspired by:
+            REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
+            REM Drive-letter needs to be escaped in quotes
+            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"D:\""
+        )
+        if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
+            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
+            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"C:\""
+        )
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -25,7 +25,7 @@ if "%CONDA_BLD_PATH%" == "" (
 :: Both in the recipe and in the final package, this script is co-located with SetPageFileSize.ps1, see meta.yaml
 set ThisScriptsDirectory=%~dp0
 set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
-:: Only run if SET_PAGEFILE is set; EntryPointPath needs to be set before if not using delayed execution.
+:: Only run if SET_PAGEFILE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
 if "%SET_PAGEFILE%" NEQ "" (
     if "%CI%" == "azure" (
         REM use different drive than CONDA_BLD_PATH-location for pagefile

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8GB"""" -MaximumSize """"8GB"""" -DiskRoot """""C:""""" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """8GB""" -MaximumSize """8GB""" -DiskRoot """"C:"""" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ^"D:^""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ""D:"" "
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ^"C:^""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ""C:"" "
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ^"D:^""
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "C:""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ^"C:^""
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -23,20 +23,18 @@ if "%CONDA_BLD_PATH%" == "" (
 )
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
-:: Both in the recipe and in the final package, this script is co-located with
-:: SetPageFileSize.ps1 & ExecuteSetPageFileSize.bat, see meta.yaml
+:: Both in the recipe and in the final package, this script is co-located with SetPageFileSize.ps1, see meta.yaml
 set ThisScriptsDirectory=%~dp0
-set EntryPointPath=%ThisScriptsDirectory%ExecuteSetPageFileSize.bat
+set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
 if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        REM Arguments are -MinimumSize, -MaximumSize, -DiskRoot see ExecuteSetPageFileSize.bat
-        call %EntryPointPath% 8GB 8GB D:
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"D:\""
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        call %EntryPointPath% 8GB 8GB C:
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"C:\""
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -23,16 +23,20 @@ if "%CONDA_BLD_PATH%" == "" (
 )
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
+:: Both in the recipe and in the final package, this script is co-located with
+:: SetPageFileSize.ps1 & ExecuteSetPageFileSize.bat, see meta.yaml
+set ThisScriptsDirectory=%~dp0
+set EntryPointPath=%ThisScriptsDirectory%ExecuteSetPageFileSize.bat
 if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        REM this file will be run within %SCRIPTS%, where SetPageFileSize.ps1/ExecuteSetPageFileSize.bat is also copied into, see meta.yaml
-        call ExecuteSetPageFileSize.bat 8GB 8GB "D:"
+        REM Arguments are -MinimumSize, -MaximumSize, -DiskRoot see ExecuteSetPageFileSize.bat
+        call %EntryPointPath% 8GB 8GB "D:"
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        call ExecuteSetPageFileSize.bat 8GB 8GB "C:"
+        call %EntryPointPath% 8GB 8GB "C:"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """"C:"""" "
+        PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" '
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command '& "%EntryPointPath%" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:"'
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:""
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command '& "%EntryPointPath%" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "C:"'
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "C:""
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot D:"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command '& "%EntryPointPath%" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "D:"'
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot C:"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command '& "%EntryPointPath%" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot "C:"'
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ""D:"" "
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """"D:"""" "
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot ""C:"" "
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """"C:"""" "
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" ' -Verb RunAs}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" ' -PassThru}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -1,3 +1,4 @@
+@echo on
 
 :: 2 cores available on Appveyor workers: https://www.appveyor.com/docs/build-environment/#build-vm-configurations
 :: CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" '}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize 8GB -MaximumSize 8GB -DiskRoot """""C:""""" ' -Verb RunAs}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8589934592"""" -MaximumSize """"8589934592"""" -DiskRoot """"C:"""" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File `"%EntryPointPath%`" -MinimumSize `"8589934592`" -MaximumSize `"8589934592`" -DiskRoot `"C:`" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -32,11 +32,11 @@ if "%CI%" == "azure" (
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
         REM Arguments are -MinimumSize, -MaximumSize, -DiskRoot see ExecuteSetPageFileSize.bat
-        call %EntryPointPath% 8GB 8GB "D:"
+        call %EntryPointPath% 8GB 8GB D:
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        call %EntryPointPath% 8GB 8GB "C:"
+        call %EntryPointPath% 8GB 8GB C:
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -34,7 +34,7 @@ if "%CI%" == "azure" (
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8GB"""" / 1 -MaximumSize """"8GB"""" / 1 -DiskRoot """"C:"""" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8589934592"""" -MaximumSize """"8589934592"""" -DiskRoot """"C:"""" ' -NoNewWindow -Wait}"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,11 +30,11 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"D:\""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot 'D:'"
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"C:\""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot 'C:'"
     )
 )
 

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -30,20 +30,14 @@ if "%CI%" == "azure" (
     REM use different drive than CONDA_BLD_PATH-location for pagefile
     if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
-        REM Everything about this is horrible; first, we need to call PowerShell scripts differently, see:
+        REM Inspired by:
         REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
-        REM Furthermore, we absolutely need to pass -DiskRoot wrapped in quotes due to the colon, but that conflicts with
-        REM the quotes necessary for the PowerShell invocation; escapes don't work, single quotes have other semantics,
-        REM and so we use the second, more involved, version of invocation from the blog (without the -Verb RunAs) that
-        REM inexplicably uses 4 quotes (and needs more options to actually see the output). This method then also manages
-        REM to break the default casting behaviour of "8GB" to UInt64, and so we pass 8 * 2^30 = 8589934592 explicitly.
-        REM The quoting of the drive letter was arrived at by trial and error (using echos in SetPageFileSize.ps1),
-        REM if you have better version (or better: an explanation), please open a PR.
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8589934592"""" -MaximumSize """"8589934592"""" -DiskRoot """"""""D:"""""""""""" ' -NoNewWindow -Wait}"
+        REM Drive-letter needs to be escaped in quotes
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"D:\""
     )
     if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
         echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File """"%EntryPointPath%"""" -MinimumSize """"8589934592"""" -MaximumSize """"8589934592"""" -DiskRoot """"""""C:"""""""""""" ' -NoNewWindow -Wait}"
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"C:\""
     )
 )
 


### PR DESCRIPTION
As [mentioned](https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/157#issuecomment-875109296) in #157, something is still not working with resetting the pagefile size - or the 4GB are not enough for some reason.

In any case, the errors with `OSError: [WinError 1455] The paging file is too small for this operation to complete` are still occurring in the numpy feedstock (e.g. [this](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=350018&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213) run for https://github.com/conda-forge/numpy-feedstock/pull/238), so add some echos to see what's happening.

CC @isuruf @mattip