### PR TITLE
allow specifying pagefile size

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.10.1" %}
+{% set version = "3.10.2" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -26,19 +26,19 @@ if "%CONDA_BLD_PATH%" == "" (
 set ThisScriptsDirectory=%~dp0
 set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
 :: Only run if SET_PAGEFILE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
-if "%SET_PAGEFILE%" NEQ "" (
+if "%SET_PAGEFILE_SIZE%" NEQ "" (
     if "%CI%" == "azure" (
         REM use different drive than CONDA_BLD_PATH-location for pagefile
         if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
-            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on D:
+            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %SET_PAGEFILE_SIZE% on D:
             REM Inspired by:
             REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
             REM Drive-letter needs to be escaped in quotes
-            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"D:\""
+            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize %SET_PAGEFILE_SIZE% -MaximumSize %SET_PAGEFILE_SIZE% -DiskRoot \"D:\""
         )
         if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
-            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 8GB on C:
-            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 8GB -DiskRoot \"C:\""
+            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %SET_PAGEFILE_SIZE% on C:
+            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize %SET_PAGEFILE_SIZE% -MaximumSize %SET_PAGEFILE_SIZE% -DiskRoot \"C:\""
         )
     )
 )


### PR DESCRIPTION
So, the good news is, #158 finally worked (e.g. there are no more errors on the numpy feedstock).

However, while testing https://github.com/conda-forge/scipy-feedstock/pull/172, I ran into a pagefile error _despite_ having set it [successfully](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=361448&view=logs&j=533b006e-c27f-58a3-8df4-b5a79e785988&t=feae41b8-2b60-5362-43eb-d6cd159242da).

I'd like to modify the guard to allow each feedstock to set that variable as they require (rather than defaulting to 8GB).

Legal values are integers (in bytes) and stuff like "1GB"/"2GB"/"3GB", etc.

CC @isuruf