### PR TITLE
[ci skip] move default branch from master to main

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: automerge-action
         id: automerge-action
-        uses: conda-forge/automerge-action@master
+        uses: conda-forge/automerge-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@master
+        uses: conda-forge/webservices-dispatch-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,6 @@ provider:
   linux_aarch64: default
   linux_ppc64le: default
 test_on_native_only: true
+github:
+  branch_name: main
+  tooling_branch_name: main


### PR DESCRIPTION
This PR moves the default branch from master to main. How to merge:

1. Merge this PR to master
2. In the settings, rename master to main
3. Submit an automated rerender command in another PR to make sure things are working. 
4. Bump the build number in the PR in 3 and merge.
5. Make sure that uploads.