### PR TITLE
use latest compatible conda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - pip
   run:
     - python
-    - conda >=4.3
+    - conda >=4.12,<4.13
     - conda-env
     - click
     - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.20.1" %}
+{% set version = "3.20.2" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
@isuruf please note that this doesn't fix anything as we have the same constraint in `boa` which is actually triggering the issue. However, this will at least force the latest compatible conda version to be used.