### PR TITLE
Show traceback if upload fails

### DIFF
--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -101,7 +101,7 @@ def built_distribution_already_exists(cli, name, version, fname, owner):
 
 
 def upload(token_fn, path, owner, channels, private_upload=False):
-    cmd = ['anaconda', '--quiet', '-t', token_fn,
+    cmd = ['anaconda', '--quiet', ' --show-traceback', '-t', token_fn,
            'upload', path, '--user={}'.format(owner),
            '--channel={}'.format(channels)]
     if private_upload:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.24.3" %}
+{% set version = "3.24.4" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
Hopefully this will provide us a bit more context as to why a particular upload has failed. Also worth noting that this works fine with the `--quiet` option.

cc @mbargull

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/215

<!--
Please add any other relevant info below:
-->
