### PR TITLE
Fix finding yum_requirements.txt when recipe dir is non-standard

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -15,8 +15,8 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
     fi
     if [[ "${BUILD_PLATFORM}" == "linux-64" && "${HOST_PLATFORM}" == linux-* ]]; then
         mamba create -n sysroot_${HOST_PLATFORM} --yes --quiet sysroot_${HOST_PLATFORM}
-        if [[ -f ${CI_SUPPORT}/../recipe/yum_requirements.txt ]]; then
-            for pkg in $(cat ${CI_SUPPORT}/../recipe/yum_requirements.txt); do
+        if [[ -f ${RECIPE_ROOT}/yum_requirements.txt ]]; then
+            for pkg in $(cat ${RECIPE_ROOT}/yum_requirements.txt); do
                 if [[ "${pkg}" != "#"* && "${pkg}" != "" ]]; then
                     mamba install "${pkg}-cos7-${HOST_PLATFORM:6}" -n sysroot_${HOST_PLATFORM} --yes --quiet || true
                 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.24.6" %}
+{% set version = "3.24.7" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] ~~Bumped the build number (if the version is unchanged)~~
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This modifies `cross_compile_support.sh` to look for `yum_requirements.txt` using the already-set `$RECIPE_ROOT` variable instead of `$CI_SUPPORT/../recipe/`. It's a bit of an esoteric case, but this fixes installing the `yum_requirements.txt` packages into a sysroot when cross-compiling AND `conda-forge.yml` has been configured with a non-standard recipe dir. That in turn fixes running tests on `linux-aarch64` for [a non-conda-forge package](https://github.com/ryanvolz/gr-radar) that uses `libgl.so.1` where I'm using conda-smithy to provide CI.

I tested this by building my own `conda-forge-ci-setup` package with this change and using it with the `remote_ci_setup` key in `conda-forge.yml` for the aforementioned package.