### PR TITLE
Cross cuda CI

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,6 +24,22 @@ jobs:
         CONFIG: linux_64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython:
         CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -40,38 +56,103 @@ jobs:
         CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
-      linux_aarch64_python3.10.____cpython:
-        CONFIG: linux_aarch64_python3.10.____cpython
+      linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython:
+        CONFIG: linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_python3.11.____cpython:
-        CONFIG: linux_aarch64_python3.11.____cpython
+      linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython:
+        CONFIG: linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_python3.8.____cpython:
-        CONFIG: linux_aarch64_python3.8.____cpython
+      linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython:
+        CONFIG: linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_python3.9.____cpython:
-        CONFIG: linux_aarch64_python3.9.____cpython
+      linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython:
+        CONFIG: linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_python3.10.____cpython:
-        CONFIG: linux_ppc64le_python3.10.____cpython
+      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython:
+        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_python3.11.____cpython:
-        CONFIG: linux_ppc64le_python3.11.____cpython
+      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython:
+        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_python3.8.____cpython:
-        CONFIG: linux_ppc64le_python3.8.____cpython
+      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython:
+        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_python3.9.____cpython:
-        CONFIG: linux_ppc64le_python3.9.____cpython
+      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython:
+        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython:
+        CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython:
+        CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython:
+        CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython:
+        CONFIG: linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+      linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython:
+        CONFIG: linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+    maxParallel: 35
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -32,6 +32,7 @@ jobs:
       osx_arm64_python3.9.____cpython:
         CONFIG: osx_arm64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -32,6 +32,7 @@ jobs:
       win_64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython:
         CONFIG: win_64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+    maxParallel: 8
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython.yaml
@@ -1,5 +1,9 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -12,6 +16,10 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
@@ -19,11 +27,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - linux-aarch64
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython.yaml
@@ -1,3 +1,11 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -8,6 +16,10 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
@@ -15,11 +27,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython.yaml
@@ -1,3 +1,11 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -5,9 +13,13 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
@@ -17,9 +29,11 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython.yaml
@@ -1,0 +1,39 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython.yaml
@@ -1,5 +1,9 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -9,21 +13,27 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cuda:11.2
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - linux-aarch64
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython.yaml
@@ -1,7 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-cdt_arch:
-- aarch64
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,6 +12,10 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
@@ -19,11 +23,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython.yaml
@@ -1,7 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-cdt_arch:
-- aarch64
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,6 +12,10 @@ cuda_compiler:
 - None
 cuda_compiler_version:
 - None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
@@ -19,11 +23,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
 cdt_name:
 - cos7
 channel_sources:
@@ -5,9 +9,13 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
@@ -15,11 +23,13 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 target_platform:
 - linux-ppc64le
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image

--- a/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
 cdt_name:
 - cos7
 channel_sources:
@@ -5,11 +9,15 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_compiler:
-- None
+- nvcc
 cuda_compiler_version:
-- None
+- '11.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cuda:11.2
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,7 +27,9 @@ python:
 target_platform:
 - linux-ppc64le
 zip_keys:
-- - cuda_compiler
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
   - cuda_compiler_version
   - cdt_name
   - docker_image

--- a/.ci_support/migrations/cuda120.yaml
+++ b/.ci_support/migrations/cuda120.yaml
@@ -1,0 +1,80 @@
+migrator_ts: 1682985063
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  paused: false
+  override_cbc_keys:
+    - cuda_compiler_stub
+  operation: key_add
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  ordering:
+    cxx_compiler_version:
+      - 9
+      - 8
+      - 7
+    c_compiler_version:
+      - 9
+      - 8
+      - 7
+    fortran_compiler_version:
+      - 9
+      - 8
+      - 7
+    docker_image:
+      - quay.io/condaforge/linux-anvil-comp7              # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-aarch64            # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+      - quay.io/condaforge/linux-anvil-ppc64le            # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+      - quay.io/condaforge/linux-anvil-armv7l             # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
+      - quay.io/condaforge/linux-anvil-cuda:9.2           # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:10.0          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:10.1          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:10.2          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.0          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.1          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.2          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cos7-x86_64        # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    cuda_compiler_version:
+      - None
+      - 10.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.1                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 12.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  commit_message: |
+    Rebuild for CUDA 12
+    
+    The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
+    build tools. Notably, the cudatoolkit package no longer exists, and packages
+    should depend directly on the specific CUDA libraries (libcublas, libcusolver,
+    etc) as needed. For an in-depth overview of the changes and to report problems
+    [see this issue]( https://github.com/conda-forge/conda-forge.github.io/issues/1963 ).
+    Please feel free to raise any issues encountered there. Thank you! :pray:
+
+cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cuda-nvcc                  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cuda_compiler_version:         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12.0                       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+c_compiler_version:            # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cxx_compiler_version:          # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+fortran_compiler_version:      # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cudnn:                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 8                          # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cdt_name:                      # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cos7                       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+docker_image:                                      # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - quay.io/condaforge/linux-anvil-cos7-x86_64     # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/.ci_support/migrations/cuda120_ppc64le_aarch64.yaml
+++ b/.ci_support/migrations/cuda120_ppc64le_aarch64.yaml
@@ -1,0 +1,49 @@
+migrator_ts: 1683090168
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  # Pausing to start on CUDA 12.0 `x86_64` migrator first
+  paused: true
+  longterm: true
+  override_cbc_keys:
+    - cuda_compiler_stub
+  operation: key_add
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  wait_for_migrators:
+    - aarch64 and ppc64le addition
+  exclude_pinned_pkgs: False
+  commit_message: "Rebuild for cuda 12 on ppc64le and aarch64"
+
+arm_variant_type:              # [aarch64]
+  - sbsa                       # [aarch64]
+
+c_compiler_version:            # [ppc64le or aarch64]
+  - 10                         # [ppc64le or aarch64]
+cxx_compiler_version:          # [ppc64le or aarch64]
+  - 10                         # [ppc64le or aarch64]
+fortran_compiler_version:      # [ppc64le or aarch64]
+  - 10                         # [ppc64le or aarch64]
+
+cuda_compiler:                 # [ppc64le or aarch64]
+  - cuda-nvcc                  # [ppc64le or aarch64]
+cuda_compiler_version:         # [ppc64le or aarch64]
+  - 12.0                       # [ppc64le or aarch64]
+
+cudnn:                         # [ppc64le or aarch64]
+  - 8                          # [ppc64le or aarch64]
+
+cdt_name:                      # [ppc64le or aarch64]
+  - cos7                       # [ppc64le or aarch64]
+
+docker_image:                                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") and (ppc64le or aarch64)]
+   # case: native compilation (build == target)
+   - quay.io/condaforge/linux-anvil-ppc64le             # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+   - quay.io/condaforge/linux-anvil-aarch64             # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+   # case: cross-compilation (build != target)
+   - quay.io/condaforge/linux-anvil-cos7-x86_64         # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+   - quay.io/condaforge/linux-anvil-cos7-x86_64         # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/.ci_support/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -1,0 +1,45 @@
+migrator_ts: 1645421738
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  paused: false
+  override_cbc_keys:
+    - cuda_compiler_stub
+  operation: key_add
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  wait_for_migrators:
+    - aarch64 and ppc64le addition
+  exclude_pinned_pkgs: False
+  commit_message: "Rebuild for cuda for ppc64le and aarch64"
+
+arm_variant_type:              # [aarch64]
+  - sbsa                       # [aarch64]
+
+c_compiler_version:            # [ppc64le or aarch64]
+  - 10                         # [ppc64le or aarch64]
+cxx_compiler_version:          # [ppc64le or aarch64]
+  - 10                         # [ppc64le or aarch64]
+fortran_compiler_version:      # [ppc64le or aarch64]
+  - 10                         # [ppc64le or aarch64]
+
+cuda_compiler_version:         # [ppc64le or aarch64]
+  - 11.2                       # [ppc64le or aarch64]
+
+cudnn:                  # [ppc64le or aarch64]
+  - 8                   # [ppc64le or aarch64]
+
+cdt_name:  # [ppc64le or aarch64]
+  - cos7   # [ppc64le or aarch64]
+
+docker_image:                                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") and (ppc64le or aarch64)]
+   # case: native compilation (build == target)
+   - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2   # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+   - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2   # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+   # case: cross-compilation (build != target)
+   - quay.io/condaforge/linux-anvil-cuda:11.2           # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+   - quay.io/condaforge/linux-anvil-cuda:11.2           # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
@@ -83,59 +111,171 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.10.____cpython</td>
+              <td>linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.11.____cpython</td>
+              <td>linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.8.____cpython</td>
+              <td>linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.9.____cpython</td>
+              <td>linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.10.____cpython</td>
+              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.11.____cpython</td>
+              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.8.____cpython</td>
+              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.9.____cpython</td>
+              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilerNonecuda_compiler_versionNonepython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilercuda-nvcccuda_compiler_version12.0python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5375&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/conda-forge-ci-setup-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cuda_compilernvcccuda_compiler_version11.2python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -104,6 +104,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                     echo "Downloading & installing: $fn"
                     curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${CUDA_HOST_PLATFORM_ARCH}/${fn}
                     bsdtar -xvf ${fn}
+                    rm ${fn}
                 done
                 # daisy-chain the copying because the docker images only have very specific combinations allowed, see
                 # https://github.com/conda-forge/docker-images/blob/main/scripts/run_commands

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,6 @@ source:
 
 build:
   number: {{ build }}
-  {% if cuda_compiler_version.startswith("12") %}
-  skip: True
-  {% endif %}
   script:
     - cp {{ os.environ["FEEDSTOCK_ROOT"] }}/LICENSE.txt ${RECIPE_DIR}/LICENSE.txt            # [linux]
     - cp ${RECIPE_DIR}/../LICENSE.txt ${RECIPE_DIR}/LICENSE.txt                              # [osx]


### PR DESCRIPTION
Follow-up to #234 & #235, trying to add CI that exercises `cross_compile_support.sh` - even though we don't exactly need those packages for the infra to run, I think it's better to have them tested on the feedstock of their origin.