### PR TITLE
Force metadata refresh on upload

### DIFF
--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -100,7 +100,7 @@ def built_distribution_already_exists(cli, name, version, fname, owner):
     return exists
 
 
-def upload(token_fn, path, owner, channels, private_upload=False, force_metadata_update=False):
+def upload(token_fn, path, owner, channels, private_upload=False, force_metadata_update=True):
     cmd = ['anaconda', '--quiet', '--show-traceback', '-t', token_fn,
            'upload', path, '--user={}'.format(owner),
            '--channel={}'.format(channels)]

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -100,12 +100,14 @@ def built_distribution_already_exists(cli, name, version, fname, owner):
     return exists
 
 
-def upload(token_fn, path, owner, channels, private_upload=False):
+def upload(token_fn, path, owner, channels, private_upload=False, force_metadata_update=False):
     cmd = ['anaconda', '--quiet', '--show-traceback', '-t', token_fn,
            'upload', path, '--user={}'.format(owner),
            '--channel={}'.format(channels)]
     if private_upload:
         cmd.append("--private")
+    if force_metadata_update:
+        cmd.append("--force-metadata-update")
     subprocess.check_call(cmd,  env=os.environ)
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.31.0" %}
+{% set version = "3.31.1" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - conda-env
     - click
     - jinja2
-    - anaconda-client >=1.11.0
+    - anaconda-client >=1.11.2
     - conda-build 3.*
     - shyaml
     - jq  # [unix]


### PR DESCRIPTION
Follow up to discussion ( https://github.com/conda/infrastructure/discussions/649 )

Add an option to force metadata refresh

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
