### PR TITLE
Allow cross-compilation with CUDA 12

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -118,10 +118,16 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
         elif [[ "${CUDA_COMPILER_VERSION}" == "11.2" ]]; then
             echo "cross compiling with cuda == 11.2 and cdt != cos7/8 not supported yet"
             exit 1
+        elif [[ "${CUDA_COMPILER_VERSION}" == "12.0" ]] && [[ "${CDT_NAME}" == "cos7" ]]; then
+            # No extra steps necessary for CUDA 12, handled through new packages
+            true
+        elif [[ "${CUDA_COMPILER_VERSION}" == "12.0" ]]; then
+            echo "cross compiling with cuda == 12.0 and cdt != cos7 not supported yet"
+            exit 1
         elif [[ "${CUDA_COMPILER_VERSION}" != "None" ]]; then
             # FIXME: can use anaconda.org/nvidia packages to get the includes and libs
             # for cuda >=11.3.
-            echo "cross compiling with cuda != 11.2 not supported yet"
+            echo "cross compiling with cuda not in (11.2, 12.0) not supported yet"
             exit 1
         fi
     fi

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -116,13 +116,13 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
             popd
             rm -rf ${EXTRACT_DIR}
         elif [[ "${CUDA_COMPILER_VERSION}" == "11.2" ]]; then
-	    echo "cross compiling with cuda == 11.2 and cdt != cos7/8 not supported yet"
-	    exit 1
+            echo "cross compiling with cuda == 11.2 and cdt != cos7/8 not supported yet"
+            exit 1
         elif [[ "${CUDA_COMPILER_VERSION}" != "None" ]]; then
-	    # FIXME: can use anaconda.org/nvidia packages to get the includes and libs
-	    # for cuda >=11.3.
-	    echo "cross compiling with cuda != 11.2 not supported yet"
-	    exit 1
+            # FIXME: can use anaconda.org/nvidia packages to get the includes and libs
+            # for cuda >=11.3.
+            echo "cross compiling with cuda != 11.2 not supported yet"
+            exit 1
         fi
     fi
 fi

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -53,7 +53,9 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 # packages for which we also need to install the -devel version
                 # (names need "_" not "-" to match spelling in manifest);
                 # some packages don't have a key in the manifest, so we
-                # need to do a mapping, in this case new_key:from_old
+                # need to do a mapping, in this case new_key:from_old;
+                # also new_key needs "_" not "-" as jq stumbles otherwise,
+                # will be mapped to "-" below for rpm-names anyway
                 declare -a DEVELS=(
                     "cuda_cudart_devel:cuda_cudart"
                     "cuda_driver_devel:cuda_cudart"
@@ -80,8 +82,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 # collect as <pkg>:<ver> to avoid further json-parsing within loop
                 jq 'keys[] as $k | "\($k):\(.[$k] | .version)"' manifest_ext.json > versions.txt
 
-                # map names from spelling in manifest to RPMs:
-                # remove quotes; normalize "_" -> "-"; remove "-api" suffix from cuda-sanitizer;
+                # map names from spelling in manifest to RPMs: remove quotes; normalize "_" -> "-";
                 # also need to adapt "_dev" -> "-devel" (specifically for cuda_nvml_dev), which
                 # in turn requires us to undo the "overshoot" for the other devel-packages
                 sed 's/"//g' versions.txt | sed 's/_/-/g' | sed 's/-api//g' | sed 's/-dev/-devel/g' | sed 's/-develel/-devel/g' > rpms.txt


### PR DESCRIPTION
Trying to use CUDA 12 in https://github.com/conda-forge/arrow-cpp-feedstock/pull/1120, and it fails unsurprisingly because the branches here make it so.

Also picking up a minor comment improvement from #236