### PR TITLE
remove CUDA 11 rpm's after installing

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -104,6 +104,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                     echo "Downloading & installing: $fn"
                     curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${CUDA_HOST_PLATFORM_ARCH}/${fn}
                     bsdtar -xvf ${fn}
+                    rm ${fn}
                 done
                 # daisy-chain the copying because the docker images only have very specific combinations allowed, see
                 # https://github.com/conda-forge/docker-images/blob/main/scripts/run_commands

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.32.4" %}
+{% set version = "3.32.5" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
This amounts to about 2GB of useless stuff in the image.

<details>
<summary>selected large CUDA rpms from the install logs</summary>

```
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-nvcc-11-2-11.2.152-1.aarch64.rpm
100 57.8M  100 57.8M    0     0   108M      0 --:--:-- --:--:-- --:--:--  108M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-nvrtc-11-2-11.2.152-1.aarch64.rpm
100 32.8M  100 32.8M    0     0  99.1M      0 --:--:-- --:--:-- --:--:-- 99.2M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcublas-11-2-11.4.1.1043-1.aarch64.rpm
100  194M  100  194M    0     0   118M      0  0:00:01  0:00:01 --:--:--  118M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcublas-devel-11-2-11.4.1.1043-1.aarch64.rpm
100  203M  100  203M    0     0   116M      0  0:00:01  0:00:01 --:--:--  116M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcufft-11-2-10.4.1.152-1.aarch64.rpm
100  144M  100  144M    0     0   113M      0  0:00:01  0:00:01 --:--:--  113M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcufft-devel-11-2-10.4.1.152-1.aarch64.rpm
100  250M  100  250M    0     0   117M      0  0:00:02  0:00:02 --:--:--  117M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcurand-11-2-10.2.3.152-1.aarch64.rpm
100 51.0M  100 51.0M    0     0   104M      0 --:--:-- --:--:-- --:--:--  103M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcurand-devel-11-2-10.2.3.152-1.aarch64.rpm
100 51.4M  100 51.4M    0     0  99.4M      0 --:--:-- --:--:-- --:--:-- 99.6M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcusolver-11-2-11.1.0.152-1.aarch64.rpm
100  264M  100  264M    0     0   116M      0  0:00:02  0:00:02 --:--:--  116M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcusolver-devel-11-2-11.1.0.152-1.aarch64.rpm
100 47.6M  100 47.6M    0     0  56.3M      0 --:--:-- --:--:-- --:--:-- 56.3M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcusparse-11-2-11.4.1.1152-1.aarch64.rpm
100  158M  100  158M    0     0   115M      0  0:00:01  0:00:01 --:--:--  1
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libcusparse-devel-11-2-11.4.1.1152-1.aarch64.rpm
100  318M  100  318M    0     0  84.0M      0  0:00:03  0:00:03 --:--:-- 84.0M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libnpp-11-2-11.3.2.152-1.aarch64.rpm
100  104M  100  104M    0     0   117M      0 --:--:-- --:--:-- --:--:--  117M
curl -L -O https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/libnpp-devel-11-2-11.3.2.152-1.aarch64.rpm
100  105M  100  105M    0     0   119M      0 --:--:-- --:--:-- --:--:--  119M
```

</details>