### PR TITLE
Start using `conda`'s `libmamba` `solver` in CI

### DIFF
--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -5,6 +5,7 @@ export PYTHONUNBUFFERED=1
 conda config --env --set show_channel_urls true
 conda config --env --set auto_update_conda false
 conda config --env --set add_pip_as_python_dependency false
+conda config --env --set solver libmamba
 # Otherwise packages that don't explicitly pin openssl in their requirements
 # are forced to the newest OpenSSL version, even if their dependencies don't
 # support it.

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -9,6 +9,7 @@ export PYTHONUNBUFFERED=1
 conda config --env --set show_channel_urls true
 conda config --env --set auto_update_conda false
 conda config --env --set add_pip_as_python_dependency false
+conda config --env --set solver libmamba
 # Otherwise packages that don't explicitly pin openssl in their requirements
 # are forced to the newest OpenSSL version, even if their dependencies don't
 # support it.

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -8,6 +8,7 @@ set PYTHONUNBUFFERED=1
 conda.exe config --set show_channel_urls true
 conda.exe config --set auto_update_conda false
 conda.exe config --set add_pip_as_python_dependency false
+conda.exe config --set solver libmamba
 :: Otherwise packages that don't explicitly pin openssl in their requirements
 :: are forced to the newest OpenSSL version, even if their dependencies don't
 :: support it.


### PR DESCRIPTION
Go ahead and opt-in to using `conda`'s `libmamba` `solver`. This will soon become the default. So it would be good to get a head start using this.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
