### PR TITLE
increase default MACOSX SDK version to 10.13

### DIFF
--- a/recipe/download_osx_sdk.sh
+++ b/recipe/download_osx_sdk.sh
@@ -7,11 +7,6 @@ export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.9}
 # Some project require a new SDK version even though they can target older versions
 if [ -f ${CI_SUPPORT}/${CONFIG}.yaml ]; then
     export MACOSX_SDK_VERSION=$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value MACOSX_SDK_VERSION.0 0)
-    export WITH_LATEST_OSX_SDK=$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value WITH_LATEST_OSX_SDK.0 0)
-    if [[ "${WITH_LATEST_OSX_SDK}" != "0" ]]; then
-        echo "Setting WITH_LATEST_OSX_SDK is removed. Use MACOSX_SDK_VERSION to specify an explicit version for the SDK."
-        export MACOSX_SDK_VERSION=10.15
-    fi
 fi
 
 if [[ "${MACOSX_SDK_VERSION:-0}" == "0" ]]; then

--- a/recipe/download_osx_sdk.sh
+++ b/recipe/download_osx_sdk.sh
@@ -15,7 +15,9 @@ if [ -f ${CI_SUPPORT}/${CONFIG}.yaml ]; then
 fi
 
 if [[ "${MACOSX_SDK_VERSION:-0}" == "0" ]]; then
-    export MACOSX_SDK_VERSION=$MACOSX_DEPLOYMENT_TARGET
+    # ensure minimal SDK of 10.13, while treatement of
+    # deployment targets <10.13 is being figured out
+    export MACOSX_SDK_VERSION="10.13"
 fi
 
 export CONDA_BUILD_SYSROOT="${OSX_SDK_DIR}/MacOSX${MACOSX_SDK_VERSION}.sdk"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.33.0" %}
+{% set version = "3.33.1" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
I believe this is a next reasonable step for https://github.com/conda-forge/conda-forge.github.io/issues/1844.

In particular, it would unblock various migrations for packages like abseil, where dependent feedstocks would fail already in the `# include` stage if the SDK is not up-to-date.