### PR TITLE
Add CCCL for CUDA 11.8 cross-compilation

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -85,6 +85,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 # Take version info from packages available in older CUDAs.
                 if [[ "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then
                     DEVELS+=(
+                        "cuda_cccl:cuda_cudart"
                         "cuda_profiler_api:cuda_sanitizer_api"
                     )
                 fi

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -80,8 +80,9 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                     "cuda_compat:nvidia_driver"
                 )
 
-                # the cuda-profiler-api package is only for 11.8+; steal the version
-                # from cuda_sanitizer because they are related packages?
+                # Some packages are added after CUDA 11.2+.
+                # Handle them seperately here.
+                # Take version info from packages available in older CUDAs.
                 if [[ "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then
                     DEVELS+=(
                         "cuda_profiler_api:cuda_sanitizer_api"

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -82,7 +82,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
 
                 # Some packages are added after CUDA 11.2+.
                 # Handle them seperately here.
-                # Take version info from packages available in older CUDAs.
+                # Take version info from packages available in the manifest.
                 if [[ "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then
                     DEVELS+=(
                         "cuda_profiler_api:cuda_sanitizer_api"

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -108,7 +108,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 sed 's/"//g' versions.txt | sed 's/_/-/g' | sed 's/sanitizer-api/sanitizer/g' | sed 's/-dev/-devel/g' | sed 's/-develel/-devel/g' > rpms.txt
 
                 # filter packages from manifest down to what we need for cross-compilation
-                grep -E "cuda-(compat|cudart|cupti|driver|nvcc|nvml|nvprof|nvrtc|nvtx|profiler).*|lib(cu|npp|nvjpeg).*" rpms.txt > rpms_cc.txt
+                grep -E "cuda-(cccl|compat|cudart|cupti|driver|nvcc|nvml|nvprof|nvrtc|nvtx|profiler).*|lib(cu|npp|nvjpeg).*" rpms.txt > rpms_cc.txt
 
                 echo "Installing the following packages (<pkg>:<version>)"
                 cat rpms_cc.txt

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -85,7 +85,6 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 # Take version info from packages available in older CUDAs.
                 if [[ "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then
                     DEVELS+=(
-                        "cuda_cccl:cuda_cudart"
                         "cuda_profiler_api:cuda_sanitizer_api"
                     )
                 fi

--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -83,7 +83,9 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 # the cuda-profiler-api package is only for 11.8+; steal the version
                 # from cuda_sanitizer because they are related packages?
                 if [[ "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then
-                    DEVELS+=("cuda_profiler_api:cuda_sanitizer_api")
+                    DEVELS+=(
+                        "cuda_profiler_api:cuda_sanitizer_api"
+                    )
                 fi
 
                 # add additional packages to manifest with same version (and formatting)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "3.33.4" %}
+{% set version = "3.33.5" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
In CUDA 11.4 `cuda-cccl` was split out from `cuda-cudart-devel`. As a result CCCL is not found when cross-compiling on CUDA 11.8. To address this, make sure CCCL is installed on CUDA 11.8 when cross-compiling.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
