### PR TITLE
Support CUDA 12 + Windows

### DIFF
--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -91,15 +91,23 @@ for %%i in ("%~dp0.") do set "SCRIPT_DIR=%%~fi"
 <cuda.version set /p CUDA_VERSION=
 del cuda.version
 if not "%CUDA_VERSION%" == "None" (
-    call "%SCRIPT_DIR%\install_cuda.bat" %CUDA_VERSION%
-    if errorlevel 1 (
-        echo Could not install CUDA
-        exit 1
+    if "%CUDA_VERSION:~0,2%" == "12" (
+        :: Don't call install_cuda, as we'll get CUDA packages from CF
+        set "CUDA_PATH="
+        set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
+        :: Export CONDA_OVERRIDE_CUDA to allow __cuda to be detected on CI systems without GPUs
+        echo set "CONDA_OVERRIDE_CUDA=%CONDA_OVERRIDE_CUDA%" >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
+    ) else (
+        call "%SCRIPT_DIR%\install_cuda.bat" %CUDA_VERSION%
+        if errorlevel 1 (
+            echo Could not install CUDA
+            exit 1
+        )
+        :: We succeeded! Export paths
+        set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION%"
+        set "PATH=%PATH%;%CUDA_PATH%\bin"
+        set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
     )
-    :: We succeeded! Export paths
-    set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION%"
-    set "PATH=%PATH%;%CUDA_PATH%\bin"
-    set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
 )
 :: /CUDA
 


### PR DESCRIPTION
The logic here is to treat CUDA 12+ differently from previous CUDA versions. Specifically, for CUDA 12+ we
- do not download/extract any CUDA installer 
- do not need to set `CUDA_PATH` or update `PATH`
- but still need to set `CONDA_OVERRIDE_CUDA`

Tested in https://github.com/conda-forge/cupy-feedstock/pull/228.

cc: @conda-forge/cuda 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
