### PR TITLE
Address conda build deprecations

### DIFF
--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -5,7 +5,6 @@ import time
 import sys
 
 from conda_forge_metadata.feedstock_outputs import package_to_feedstock
-import conda_build
 import conda_build.config
 import requests
 import click

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -11,12 +11,14 @@ import time
 
 from binstar_client.utils import get_server_api
 import binstar_client.errors
-from conda_build.conda_interface import subdir as conda_subdir
-from conda_build.conda_interface import get_index
+from conda.base.context import context
+from conda.core.index import get_index
 import conda_build.api
 import conda_build.config
 
 from .feedstock_outputs import request_copy, split_pkg
+
+conda_subdir = context.subdir
 
 
 def get_built_distribution_names_and_subdirs(recipe_dir, variant):
@@ -142,11 +144,14 @@ def distribution_exists_on_channel(binstar_cli, meta, fname, owner, channel='mai
     else:
         base_fname = fname
 
-    distributions_on_channel = get_index(
-        [channel_url],
-        prepend=False,
-        use_cache=False,
-    )
+    distributions_on_channel = {
+        f"{prec.name}-{prec.version}-{prec.build}": prec
+        for prec in get_index(
+            [channel_url],
+            prepend=False,
+            use_cache=False,
+        )
+    }
 
     on_channel = False
     for ext in [".tar.bz2", ".conda"]:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.3.2" %}
+{% set version = "4.3.3" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Stop using `conda_build.conda_interface`

`conda_build.conda_interface` is being deprecated.

`conda_build.conda_interface.get_index` (which is `conda.exports.get_index`)
is using the `conda.models.Dist` -> `conda.models.records.PackageRecord`
mapping. `Dist` class is legacy code that's being phased out, so avoid it.