### PR TITLE
Fix `conda_build.config.subdir` deprecation

### DIFF
--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -5,10 +5,13 @@ import time
 import sys
 
 from conda_forge_metadata.feedstock_outputs import package_to_feedstock
+from conda.base.context import context
 import conda_build.config
 import requests
 import click
 
+
+conda_subdir = context.subdir
 
 VALIDATION_ENDPOINT = "https://conda-forge.herokuapp.com"
 STAGING = "cf-staging"
@@ -161,8 +164,8 @@ def main(feedstock_name):
             for p in os.listdir(os.path.join(conda_build.config.croot, 'noarch'))  # noqa
         ]
         + [
-            os.path.join(conda_build.config.subdir, p)
-            for p in os.listdir(os.path.join(conda_build.config.croot, conda_build.config.subdir))  # noqa
+            os.path.join(conda_subdir, p)
+            for p in os.listdir(os.path.join(conda_build.config.croot, conda_subdir))  # noqa
         ])
     built_distributions = [
         path

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ requirements:
      # ensure that all variants of cuda_compiler_version are tested
     - {{ compiler('cuda') }}              # [cuda_compiler_version != "None"]
     - {{ compiler('c') }}                 # [cuda_compiler_version != "None"]
+    - {{ stdlib('c') }}                   # [cuda_compiler_version != "None"]
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.4.6" %}
+{% set version = "4.4.7" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/317

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/305