### PR TITLE
Fix `conda_build.config.subdir` deprecation (pt. 2)

### DIFF
--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -226,7 +226,7 @@ def upload_or_check(
 
     # The list of built distributions
     paths = set()
-    for subdir in list(allowed_subdirs) + [conda_build.config.subdir, 'noarch']:
+    for subdir in list(allowed_subdirs) + [conda_subdir, 'noarch']:
         if not os.path.exists(os.path.join(conda_build.config.croot, subdir)):
             continue
         for p in os.listdir(os.path.join(conda_build.config.croot, subdir)):


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/317

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
