### PR TITLE
disallow uploading from `rattler-build` feedstocks

### DIFF
--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -234,9 +234,9 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
         # when building packages with `rattler-build`
         if any(["label/" not in channels]):
             print(
-                "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build\n"
+                "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build.\n"
                 "You can set a label channel in the channel_targets section of the config file\n"
-                "to upload to a label channel"
+                "to upload to a label channel."
             )
             return
 

--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -232,7 +232,7 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
     if build_tool != CONDA_BUILD and upload_to_conda_forge:
         # make sure that we are not uploading to the main conda-forge channel
         # when building packages with `rattler-build`
-        if any([label == "main" for owner, label in channels]):
+        if any(owner == "conda-forge" and label == "main" for owner, label in channels):
             print(
                 "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build.\n"
                 "You can set a label channel in the channel_targets section of the config file\n"

--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -232,7 +232,7 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
     if build_tool != CONDA_BUILD and upload_to_conda_forge:
         # make sure that we are not uploading to the main conda-forge channel
         # when building packages with `rattler-build`
-        if any(["label/" not in channels]):
+        if any([label == "main" for owner, label in channels]):
             print(
                 "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build.\n"
                 "You can set a label channel in the channel_targets section of the config file\n"

--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -15,7 +15,7 @@ import click
 from conda_forge_ci_setup.upload_or_check_non_existence import retry_upload_or_check
 
 from .feedstock_outputs import STAGING
-
+from .utils import determine_build_tool, CONDA_BUILD
 
 call = subprocess.check_call
 
@@ -227,6 +227,18 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
                     "Uploading to %s with source channel '%s' "
                     "is not allowed" % ("conda-forge", source_channel))
                 return
+
+    build_tool = determine_build_tool(feedstock_root)
+    if build_tool != CONDA_BUILD and upload_to_conda_forge:
+        # make sure that we are not uploading to the main conda-forge channel
+        # when building packages with `rattler-build`
+        if any(["label/" not in channels]):
+            print(
+                "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build\n"
+                "You can set a label channel in the channel_targets section of the config file\n"
+                "to upload to a label channel"
+            )
+            return
 
     # get the git sha of the current commit
     git_sha = subprocess.run(

--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -232,7 +232,7 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
     if build_tool != CONDA_BUILD and upload_to_conda_forge:
         # make sure that we are not uploading to the main conda-forge channel
         # when building packages with `rattler-build`
-        if any(owner == "conda-forge" and label == "main" for owner, label in channels):
+        if ["conda-forge", "main"] in channels:
             print(
                 "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build.\n"
                 "You can set a label channel in the channel_targets section of the config file\n"

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -16,15 +16,11 @@ from conda.core.index import get_index
 import conda_build.api
 import conda_build.config
 import rattler_build_conda_compat.render
-from yaml import safe_load
 
 from .feedstock_outputs import request_copy, split_pkg
+from .utils import CONDA_BUILD, determine_build_tool
 
 conda_subdir = context.subdir
-
-CONDA_BUILD = "conda-build"
-RATTLER_BUILD = "rattler-build"
-
 
 def get_built_distribution_names_and_subdirs(recipe_dir, variant, build_tool=CONDA_BUILD):
     additional_config = {}
@@ -211,14 +207,7 @@ def upload_or_check(
 
     cli = get_server_api(token=token)
 
-    build_tool = CONDA_BUILD
-
-    if feedstock_root and os.path.exists(os.path.join(feedstock_root, "conda-forge.yml")):
-        with open(os.path.join(feedstock_root, "conda-forge.yml")) as f:
-            conda_forge_config = safe_load(f)
-            
-            if conda_forge_config.get("conda_build_tool", CONDA_BUILD) == RATTLER_BUILD:
-                build_tool = RATTLER_BUILD
+    build_tool = determine_build_tool(feedstock_root)
 
     allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(
         recipe_dir, variant, build_tool=build_tool

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -4,6 +4,13 @@ import os
 import conda_build.config
 from conda.base.context import context
 
+try:
+    from ruamel_yaml import safe_load
+except ImportError:
+    from yaml import safe_load
+
+CONDA_BUILD = "conda-build"
+RATTLER_BUILD = "rattler-build"
 
 def built_distributions(subdirs=()):
     "List conda artifacts in conda-build's root workspace"
@@ -47,3 +54,16 @@ def human_readable_bytes(number):
             return f"{number:3.1f}{unit}"
         number /= 1024.0
     return f"{number:3.1f}{unit}"
+
+
+def determine_build_tool(feedstock_root):
+    build_tool = CONDA_BUILD
+
+    if feedstock_root and os.path.exists(os.path.join(feedstock_root, "conda-forge.yml")):
+        with open(os.path.join(feedstock_root, "conda-forge.yml")) as f:
+            conda_forge_config = safe_load(f)
+
+            if conda_forge_config.get("conda_build_tool", CONDA_BUILD) == RATTLER_BUILD:
+                build_tool = RATTLER_BUILD
+
+    return build_tool

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.7.0" %}
+{% set version = "4.8.0" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
Also includes a small refactor to make the `determine_build_tool` function reusable.