### PR TITLE
Add a strict upper-bound to rattler-build-conda-compat

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-forge-ci-setup" %}
 {% set version = "4.8.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}
 # prioritize non-CUDA variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ requirements:
     - libarchive
     - conda-forge-metadata >=0.4.1
     - conda-package-handling >=2.3.0
-    - rattler-build-conda-compat >=0.0.2
+    - rattler-build-conda-compat >=0.0.2,<1.0.0a
 
   run_constrained:
     - boa >=0.8,<1.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR adds a strict upper bound to rattler-build-conda-compat to ensure that any semver incompatible changes will not break this package.