### PR TITLE
feat: allow uploading on main channel for v1 recipes

### DIFF
--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -228,17 +228,6 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
                     "is not allowed" % ("conda-forge", source_channel))
                 return
 
-    build_tool = determine_build_tool(feedstock_root)
-    if build_tool != CONDA_BUILD and upload_to_conda_forge:
-        # make sure that we are not uploading to the main conda-forge channel
-        # when building packages with `rattler-build`
-        if ["conda-forge", "main"] in channels:
-            print(
-                "Uploading to conda-forge's main channel is not yet allowed when building with rattler-build.\n"
-                "You can set a label channel in the channel_targets section of the config file\n"
-                "to upload to a label channel."
-            )
-            return
 
     # get the git sha of the current commit
     git_sha = subprocess.run(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.9.5" %}
+{% set version = "4.10.0" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.8.1" %}
+{% set version = "4.9.0" %}
 {% set build = 1 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

now that we have implemented all rattler-build lints checks and we have a working feedstock: https://github.com/conda-forge/jolt-physics-feedstock
I would like to uplift restrictions of uploading rattler-build to main channel.


Should be merged after release of: https://github.com/conda-forge/conda-smithy/pull/2037
