### PR TITLE
fix: skip output validation if not on

### DIFF
--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -11,7 +11,12 @@ from conda_forge_metadata.feedstock_outputs import (
     feedstock_outputs_config,
 )
 
-from .utils import built_distributions, compute_sha256sum, split_pkg
+from .utils import (
+    built_distributions,
+    compute_sha256sum,
+    split_pkg,
+    is_conda_forge_output_validation_on,
+)
 
 
 VALIDATION_ENDPOINT = "https://conda-forge.herokuapp.com"
@@ -134,16 +139,19 @@ def is_valid_feedstock_output(project, outputs):
 def main(feedstock_name):
     """Validate the feedstock outputs."""
 
-    distributions = [os.path.relpath(p, conda_build.config.croot) for p in built_distributions()]
-    results = is_valid_feedstock_output(feedstock_name, distributions)
+    if is_conda_forge_output_validation_on():
+        distributions = [os.path.relpath(p, conda_build.config.croot) for p in built_distributions()]
+        results = is_valid_feedstock_output(feedstock_name, distributions)
 
-    print("validation results:\n%s" % json.dumps(results, indent=2), flush=True)
-    print(
-        "NOTE: Any outputs marked as False are not allowed for this feedstock. "
-        "See https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens "
-        "for information on how to address this error.",
-        flush=True,
-    )
+        print("validation results:\n%s" % json.dumps(results, indent=2), flush=True)
+        print(
+            "NOTE: Any outputs marked as False are not allowed for this feedstock. "
+            "See https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens "
+            "for information on how to address this error.",
+            flush=True,
+        )
 
-    if not all(v for v in results.values()):
-        sys.exit(1)
+        if not all(v for v in results.values()):
+            sys.exit(1)
+    else:
+        print("Output validation is turned off. Skipping validation.", flush=True)

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -67,3 +67,13 @@ def determine_build_tool(feedstock_root):
                 build_tool = RATTLER_BUILD
 
     return build_tool
+
+
+def is_conda_forge_output_validation_on():
+    feedstock_root = os.environ.get("FEEDSTOCK_ROOT", "/home/conda/feedstock_root")
+    ison = False
+    if os.path.exists(os.path.join(feedstock_root, "conda-forge.yml")):
+        with open(os.path.join(feedstock_root, "conda-forge.yml")) as f:
+            conda_forge_config = safe_load(f)
+            ison = conda_forge_config.get("conda_forge_output_validation", False)
+    return ison

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.9.0" %}
+{% set version = "4.9.1" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR fixes the case where the package is used outside conda-forge or conda_forge_output_validation is turned off.

xref: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/338
