### PR TITLE
Improve installing yum requirements with conda when cross compiling

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -25,7 +25,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
         mamba create -n sysroot_${HOST_PLATFORM} --yes --quiet sysroot_${HOST_PLATFORM}=${GLIBC_VERSION}
         HOST_PLATFORM_ARCH=${HOST_PLATFORM:6}
         if [[ -f ${RECIPE_ROOT}/yum_requirements.txt ]]; then
-            for pkg in $(cat ${RECIPE_ROOT}/yum_requirements.txt); do
+            cat ${RECIPE_ROOT}/yum_requirements.txt | while read pkg; do
                 if [[ "${pkg}" != "#"* && "${pkg}" != "" ]]; then
                     mamba install "${pkg}-cos7-${HOST_PLATFORM_ARCH}" -n sysroot_${HOST_PLATFORM} --yes --quiet || true
                 fi


### PR DESCRIPTION
This MR improves the way that `cross_compile_support.sh` attempts to install `{pkg}-cos7-{host_platform}` conda packages for packages listed in `yum_requirements.txt`.

`for pkg in $(cat recipe/yum_requirements.txt)` loops over words, which doesn't ignore comments properly, while `cat recipe/yum_requirements.txt | while read pkg` loops over lines, which should.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
