### PR TITLE
fix: ensure validation is run on correct files

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 joblib
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build conda-forge-ci-setup=4
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 joblib
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build conda-forge-ci-setup=4
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 joblib -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Overriding conda-forge-ci-setup with local version
 conda.exe uninstall --quiet --yes --force conda-forge-ci-setup=4

--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -148,7 +148,7 @@ def is_valid_feedstock_output(project, outputs):
     '-m',
     multiple=True,
     type=click.Path(exists=False, file_okay=True, dir_okay=False),
-    default=None,
+    default=(),
     help="path to conda_build_config.yaml defining your base matrix",
 )
 def main(feedstock_name, recipe_dir, variant):

--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -14,7 +14,6 @@ from conda_forge_metadata.feedstock_outputs import (
 from .utils import (
     built_distributions,
     compute_sha256sum,
-    determine_build_tool,
     get_built_distribution_names_and_subdirs,
     split_pkg,
     is_conda_forge_output_validation_on,
@@ -142,20 +141,12 @@ def main(feedstock_name):
     """Validate the feedstock outputs."""
 
     if is_conda_forge_output_validation_on():
-        feedstock_root = os.environ.get(
-            "FEEDSTOCK_ROOT",
-            os.getcwd(),
-        )
-        recipe_root = os.path.join(feedstock_root, "recipe")
-        build_tool = determine_build_tool(feedstock_root)
-        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(
-            recipe_root, None, build_tool=build_tool
-        )
+        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs()
         distributions = [os.path.relpath(p, conda_build.config.croot) for p in built_distributions(subdirs=allowed_subdirs)]
         distributions = [
             dist
             for dist in distributions
-            if any(dist.startswith(allowed + "-") for allowed in allowed_dist_names)
+            if any(os.path.basename(dist).startswith(allowed + "-") for allowed in allowed_dist_names)
         ]
         results = is_valid_feedstock_output(feedstock_name, distributions)
 

--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -137,11 +137,25 @@ def is_valid_feedstock_output(project, outputs):
 
 @click.command()
 @click.argument("feedstock_name", type=str)
-def main(feedstock_name):
+@click.option(
+    '--recipe-dir',
+    type=click.Path(exists=False, file_okay=False, dir_okay=True),
+    default=None,
+    help='the conda recipe directory'
+)
+@click.option(
+    '--variant',
+    '-m',
+    multiple=True,
+    type=click.Path(exists=False, file_okay=True, dir_okay=False),
+    default=None,
+    help="path to conda_build_config.yaml defining your base matrix",
+)
+def main(feedstock_name, recipe_dir, variant):
     """Validate the feedstock outputs."""
 
     if is_conda_forge_output_validation_on():
-        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs()
+        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)
         distributions = [os.path.relpath(p, conda_build.config.croot) for p in built_distributions(subdirs=allowed_subdirs)]
         distributions = [
             dist

--- a/recipe/conda_forge_ci_setup/inspect_artifacts.py
+++ b/recipe/conda_forge_ci_setup/inspect_artifacts.py
@@ -14,8 +14,22 @@ from .utils import (
 
 
 @click.command()
-def main():
-    allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs()
+@click.option(
+    '--recipe-dir',
+    type=click.Path(exists=False, file_okay=False, dir_okay=True),
+    default=None,
+    help='the conda recipe directory'
+)
+@click.option(
+    '--variant',
+    '-m',
+    multiple=True,
+    type=click.Path(exists=False, file_okay=True, dir_okay=False),
+    default=None,
+    help="path to conda_build_config.yaml defining your base matrix",
+)
+def main(recipe_dir, variant):
+    allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)
     distributions = built_distributions(subdirs=allowed_subdirs)
     distributions = [
         dist

--- a/recipe/conda_forge_ci_setup/inspect_artifacts.py
+++ b/recipe/conda_forge_ci_setup/inspect_artifacts.py
@@ -1,15 +1,29 @@
 from pathlib import Path
+import os
 
 import click
 import conda_build.config
 from conda_package_handling.api import list_contents
 
-from .utils import built_distributions, compute_sha256sum, human_readable_bytes
+from .utils import (
+    built_distributions,
+    compute_sha256sum,
+    get_built_distribution_names_and_subdirs,
+    human_readable_bytes,
+)
 
 
 @click.command()
 def main():
-    for artifact in sorted(built_distributions()):
+    allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs()
+    distributions = built_distributions(subdirs=allowed_subdirs)
+    distributions = [
+        dist
+        for dist in distributions
+        if any(os.path.basename(dist).startswith(allowed + "-") for allowed in allowed_dist_names)
+    ]
+
+    for artifact in sorted(distributions):
         path = Path(artifact)
         relpath = path.relative_to(conda_build.config.croot)
         print("-" * len(str(relpath)))

--- a/recipe/conda_forge_ci_setup/inspect_artifacts.py
+++ b/recipe/conda_forge_ci_setup/inspect_artifacts.py
@@ -25,7 +25,7 @@ from .utils import (
     '-m',
     multiple=True,
     type=click.Path(exists=False, file_okay=True, dir_okay=False),
-    default=None,
+    default=(),
     help="path to conda_build_config.yaml defining your base matrix",
 )
 def main(recipe_dir, variant):

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -173,7 +173,7 @@ def upload_or_check(
     build_tool = determine_build_tool(feedstock_root)
 
     allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(
-        recipe_dir, variant, build_tool=build_tool
+        recipe_dir=recipe_dir, variant=variant, build_tool=build_tool
     )
 
     # The list of built distributions

--- a/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
+++ b/recipe/conda_forge_ci_setup/upload_or_check_non_existence.py
@@ -15,48 +15,11 @@ from conda.base.context import context
 from conda.core.index import get_index
 import conda_build.api
 import conda_build.config
-import rattler_build_conda_compat.render
 
 from .feedstock_outputs import request_copy, split_pkg
-from .utils import CONDA_BUILD, RATTLER_BUILD, determine_build_tool
+from .utils import determine_build_tool, get_built_distribution_names_and_subdirs
 
 conda_subdir = context.subdir
-
-def get_built_distribution_names_and_subdirs(recipe_dir, variant, build_tool=CONDA_BUILD):
-    additional_config = {}
-    for v in variant:
-        variant_dir, base_name = os.path.split(v)
-        clobber_file = os.path.join(variant_dir, 'clobber_' + base_name)
-        if os.path.exists(clobber_file):
-            additional_config = {
-                'clobber_sections_file': clobber_file
-            }
-            break
-
-    if build_tool == RATTLER_BUILD:
-        metas = rattler_build_conda_compat.render.render(
-            recipe_dir,
-            variant_config_files=variant,
-            finalize=False,
-            bypass_env_check=True,
-            **additional_config
-        )
-    else:        
-        metas = conda_build.api.render(
-            recipe_dir,
-            variant_config_files=variant,
-            finalize=False,
-            bypass_env_check=True,
-            **additional_config
-        )
-
-    # Print the skipped distributions
-    skipped_distributions = [m for m, _, _ in metas if m.skip()]
-    for m in skipped_distributions:
-        print("{} configuration was skipped in build/skip.".format(m.name()))
-
-    subdirs = set([m.config.target_subdir for m, _, _ in metas if not m.skip()])
-    return set([m.name() for m, _, _ in metas if not m.skip()]), subdirs
 
 
 @contextlib.contextmanager
@@ -348,7 +311,7 @@ def retry_upload_or_check(
 @click.option('--variant', '-m', multiple=True,
               type=click.Path(exists=True, file_okay=True, dir_okay=False),
               help="path to conda_build_config.yaml defining your base matrix")
-@click.option('--feedstock-root', '-f', 
+@click.option('--feedstock-root', '-f',
               multiple=False,
               default=None,
               type=click.Path(exists=True, file_okay=False, dir_okay=True),

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -22,11 +22,6 @@ JOBLIB_MEMORY = joblib.Memory(".joblib_cache", verbose=0)
 
 @JOBLIB_MEMORY.cache
 def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, build_tool=None):
-    print("inputs:", flush=True)
-    print("  recipe dir:", recipe_dir, flush=True)
-    print("  variants:", variant, flush=True)
-    print("  build tool:", build_tool, flush=True)
-
     feedstock_root = os.environ.get(
         "FEEDSTOCK_ROOT",
         os.getcwd(),
@@ -35,7 +30,7 @@ def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, buil
         recipe_dir = os.path.join(feedstock_root, "recipe")
     if build_tool is None:
         build_tool = determine_build_tool(feedstock_root)
-    if variant is None:
+    if not variant:
         if "CONFIG_FILE" in os.environ:
             variant = [os.environ.get("CONFIG_FILE")]
         else:
@@ -45,11 +40,6 @@ def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, buil
                     os.environ.get("CONFIG") + ".yaml"
                 )
             ]
-
-    print("final values:", flush=True)
-    print("  recipe dir:", recipe_dir, flush=True)
-    print("  variants:", variant, flush=True)
-    print("  build tool:", build_tool, flush=True)
 
     additional_config = {}
     for v in variant:

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 
+import conda_build.api
 import conda_build.config
 from conda.base.context import context
 

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -31,7 +31,7 @@ def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, buil
         else:
             variant = [
                 os.path.join(
-                    os.environ.get("CI_SUPPORT"),
+                    os.environ.get("CI_SUPPORT", os.path.join(feedstock_root, ".ci_support")),
                     os.environ.get("CONFIG") + ".yaml"
                 )
             ]
@@ -130,7 +130,7 @@ def determine_build_tool(feedstock_root):
 
 
 def is_conda_forge_output_validation_on():
-    feedstock_root = os.environ.get("FEEDSTOCK_ROOT", "/home/conda/feedstock_root")
+    feedstock_root = os.environ.get("FEEDSTOCK_ROOT", os.getcwd())
     ison = False
     if os.path.exists(os.path.join(feedstock_root, "conda-forge.yml")):
         with open(os.path.join(feedstock_root, "conda-forge.yml")) as f:

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -15,7 +15,15 @@ CONDA_BUILD = "conda-build"
 RATTLER_BUILD = "rattler-build"
 
 
-def get_built_distribution_names_and_subdirs(recipe_dir, variant, build_tool=CONDA_BUILD):
+def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, build_tool=None):
+    feedstock_root = os.environ.get(
+        "FEEDSTOCK_ROOT",
+        os.getcwd(),
+    )
+    if recipe_dir is None:
+        recipe_dir = os.path.join(feedstock_root, "recipe")
+    if build_tool is None:
+        build_tool = determine_build_tool(feedstock_root)
     if variant is None:
         if "CONFIG_FILE" in os.environ:
             variant = [os.environ.get("CONFIG_FILE")]
@@ -26,6 +34,7 @@ def get_built_distribution_names_and_subdirs(recipe_dir, variant, build_tool=CON
                     os.environ.get("CONFIG") + ".yaml"
                 )
             ]
+
     additional_config = {}
     for v in variant:
         variant_dir, base_name = os.path.split(v)

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -4,6 +4,7 @@ import os
 import conda_build.api
 import conda_build.config
 from conda.base.context import context
+import joblib
 
 try:
     from ruamel_yaml import safe_load
@@ -15,7 +16,11 @@ import rattler_build_conda_compat.render
 CONDA_BUILD = "conda-build"
 RATTLER_BUILD = "rattler-build"
 
+os.makedirs(".joblib_cache", exist_ok=True)
+JOBLIB_MEMORY = joblib.Memory(".joblib_cache", verbose=0)
 
+
+@JOBLIB_MEMORY.cache
 def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, build_tool=None):
     feedstock_root = os.environ.get(
         "FEEDSTOCK_ROOT",

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -22,6 +22,11 @@ JOBLIB_MEMORY = joblib.Memory(".joblib_cache", verbose=0)
 
 @JOBLIB_MEMORY.cache
 def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, build_tool=None):
+    print("inputs:", flush=True)
+    print("  recipe dir:", recipe_dir, flush=True)
+    print("  variants:", variant, flush=True)
+    print("  build tool:", build_tool, flush=True)
+
     feedstock_root = os.environ.get(
         "FEEDSTOCK_ROOT",
         os.getcwd(),
@@ -40,6 +45,11 @@ def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, buil
                     os.environ.get("CONFIG") + ".yaml"
                 )
             ]
+
+    print("final values:", flush=True)
+    print("  recipe dir:", recipe_dir, flush=True)
+    print("  variants:", variant, flush=True)
+    print("  build tool:", build_tool, flush=True)
 
     additional_config = {}
     for v in variant:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,7 @@ requirements:
     - m2-git  # [win]
     - git     # [unix]
     - libarchive
+    - joblib >=0.12
     - conda-forge-metadata >=0.9.2
     - conda-package-handling >=2.3.0
     - rattler-build-conda-compat >=0.0.2,<2.0.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.9.1" %}
+{% set version = "4.9.2" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
This PR ensures we run output validation only on the packages we built.

closes #342 
closes #341 