### PR TITLE
fix: allow all distributions to be inspected

### DIFF
--- a/recipe/conda_forge_ci_setup/inspect_artifacts.py
+++ b/recipe/conda_forge_ci_setup/inspect_artifacts.py
@@ -15,7 +15,7 @@ from .utils import (
 
 @click.command()
 @click.option(
-    '--all-dists',
+    '--all-packages',
     is_flag=True,
     help='inspect all packages found in the conda-build root directory'
 )
@@ -33,8 +33,8 @@ from .utils import (
     default=(),
     help="path to conda_build_config.yaml defining your base matrix",
 )
-def main(all_dists, recipe_dir, variant):
-    if all_dists:
+def main(all_packages, recipe_dir, variant):
+    if all_packages:
         distributions = built_distributions()
     else:
         allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)

--- a/recipe/conda_forge_ci_setup/inspect_artifacts.py
+++ b/recipe/conda_forge_ci_setup/inspect_artifacts.py
@@ -15,6 +15,11 @@ from .utils import (
 
 @click.command()
 @click.option(
+    '--all-dists',
+    is_flag=True,
+    help='inspect all packages found in the conda-build root directory'
+)
+@click.option(
     '--recipe-dir',
     type=click.Path(exists=False, file_okay=False, dir_okay=True),
     default=None,
@@ -28,14 +33,17 @@ from .utils import (
     default=(),
     help="path to conda_build_config.yaml defining your base matrix",
 )
-def main(recipe_dir, variant):
-    allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)
-    distributions = built_distributions(subdirs=allowed_subdirs)
-    distributions = [
-        dist
-        for dist in distributions
-        if any(os.path.basename(dist).startswith(allowed + "-") for allowed in allowed_dist_names)
-    ]
+def main(all_dists, recipe_dir, variant):
+    if all_dists:
+        distributions = built_distributions()
+    else:
+        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)
+        distributions = built_distributions(subdirs=allowed_subdirs)
+        distributions = [
+            dist
+            for dist in distributions
+            if any(os.path.basename(dist).startswith(allowed + "-") for allowed in allowed_dist_names)
+        ]
 
     for artifact in sorted(distributions):
         path = Path(artifact)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.9.2" %}
+{% set version = "4.9.3" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}


### PR DESCRIPTION
This PR fixes a bug where the inspect command broke on staged recipes. I added a flag we can use there to inspect everything.

cc @jaimergp 