### PR TITLE
fix: try again to exclude downstreams

### DIFF
--- a/recipe/conda_forge_ci_setup/feedstock_outputs.py
+++ b/recipe/conda_forge_ci_setup/feedstock_outputs.py
@@ -12,9 +12,8 @@ from conda_forge_metadata.feedstock_outputs import (
 )
 
 from .utils import (
-    built_distributions,
+    built_distributions_from_recipe_variant,
     compute_sha256sum,
-    get_built_distribution_names_and_subdirs,
     split_pkg,
     is_conda_forge_output_validation_on,
 )
@@ -154,14 +153,10 @@ def is_valid_feedstock_output(project, outputs):
 def main(feedstock_name, recipe_dir, variant):
     """Validate the feedstock outputs."""
 
+
     if is_conda_forge_output_validation_on():
-        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)
-        distributions = [os.path.relpath(p, conda_build.config.croot) for p in built_distributions(subdirs=allowed_subdirs)]
-        distributions = [
-            dist
-            for dist in distributions
-            if any(os.path.basename(dist).startswith(allowed + "-") for allowed in allowed_dist_names)
-        ]
+        distributions = built_distributions_from_recipe_variant(recipe_dir=recipe_dir, variant=variant)
+        distributions = [os.path.relpath(p, conda_build.config.croot) for p in distributions]
         results = is_valid_feedstock_output(feedstock_name, distributions)
 
         print("validation results:\n%s" % json.dumps(results, indent=2), flush=True)

--- a/recipe/conda_forge_ci_setup/inspect_artifacts.py
+++ b/recipe/conda_forge_ci_setup/inspect_artifacts.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import os
 
 import click
 import conda_build.config
@@ -7,8 +6,8 @@ from conda_package_handling.api import list_contents
 
 from .utils import (
     built_distributions,
+    built_distributions_from_recipe_variant,
     compute_sha256sum,
-    get_built_distribution_names_and_subdirs,
     human_readable_bytes,
 )
 
@@ -37,13 +36,7 @@ def main(all_packages, recipe_dir, variant):
     if all_packages:
         distributions = built_distributions()
     else:
-        allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(recipe_dir=recipe_dir, variant=variant)
-        distributions = built_distributions(subdirs=allowed_subdirs)
-        distributions = [
-            dist
-            for dist in distributions
-            if any(os.path.basename(dist).startswith(allowed + "-") for allowed in allowed_dist_names)
-        ]
+        distributions = built_distributions_from_recipe_variant(recipe_dir=recipe_dir, variant=variant)
 
     for artifact in sorted(distributions):
         path = Path(artifact)

--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -89,6 +89,23 @@ def built_distributions(subdirs=()):
     return paths
 
 
+def built_distributions_from_recipe_variant(recipe_dir=None, variant=None, build_tool=None):
+    def _dist_name(dist):
+        return split_pkg(os.path.relpath(dist, conda_build.config.croot))[1]
+
+    allowed_dist_names, allowed_subdirs = get_built_distribution_names_and_subdirs(
+        recipe_dir=recipe_dir,
+        variant=variant,
+        build_tool=build_tool,
+    )
+    return [
+        dist
+        for dist in built_distributions(subdirs=allowed_subdirs)
+        if _dist_name(dist) in allowed_dist_names
+    ]
+
+
+
 def split_pkg(pkg):
     if pkg.endswith(".tar.bz2"):
         pkg = pkg[:-len(".tar.bz2")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.9.3" %}
+{% set version = "4.9.4" %}
 {% set build = 0 %}
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}
 {% if cuda_compiler_version == "None" %}
@@ -101,6 +101,10 @@ test:
     - mangle_homebrew --help
     - validate_recipe_outputs --help
     - inspect_artifacts --help
+  # this is here to test that downstream test packages
+  # are excluded from validation and inspection
+  downstreams:
+    - ngmix
 
 
 about:


### PR DESCRIPTION
This PR tries to again fix validation for downstreams. The code I wrote last time was imprecise. 

cc @h-vetinari and thank you to him for catching my bug!