### PR TITLE
Add `targets` content from `cuda-nvcc` for CUDA 11

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -71,6 +71,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 declare -a DEVELS=(
                     "cuda_cudart_devel:cuda_cudart"
                     "cuda_driver_devel:cuda_cudart"
+                    "cuda_nvcc:cuda_nvcc"
                     "cuda_nvrtc_devel:cuda_nvrtc"
                     "libcublas_devel:libcublas"
                     "libcufft_devel:libcufft"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.10.2" %}
+{% set version = "4.11.0" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}


### PR DESCRIPTION
Within `cuda-nvcc`'s RPM's `targets` directory, there is some content needed for `nvPTXCompiler`, which the Numba supporting CUDA 11 package, `ptxcompiler`, uses. This makes sure it is available when cross-compiling `ptxcompiler`.

As the Docker image and `conda-forge-ci-setup` limit content to the `targets` directory, the rest of the `cuda-nvcc` content will be ignored. This is for the best to ensure these other bits are not pulled in accidentally.

xref: https://github.com/conda-forge/ptxcompiler-feedstock/pull/38

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
