### PR TITLE
Cleanup `/opt/conda/targets` CUDA bits

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -139,6 +139,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 mv ./usr/local/cuda-${CUDA_COMPILER_VERSION}/compat/* ${QEMU_LD_PREFIX}/usr/lib/
             popd
             rm -rf ${EXTRACT_DIR}
+            /usr/bin/sudo rm -rf /opt/conda/targets/${CUDA_HOST_PLATFORM_ARCH}-linux
         elif [[ "${CUDA_COMPILER_VERSION}" == "11.2" ]]; then
             echo "cross compiling with cuda == 11.2 and cdt != cos7/8 not supported yet"
             exit 1


### PR DESCRIPTION
Depends on PR: https://github.com/conda-forge/docker-images/pull/282

These are moved to `/usr/local/cuda/targets`. As a result these are unused and duplicating memory usage. This may lead to some of our challenges with CI memory in CUDA 11 cross-compilation builds. So try to cleanup after to help better manage memory.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
