### PR TITLE
Revert "Add `targets` content from `cuda-nvcc` for CUDA 11 (#356)"

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -71,7 +71,6 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
                 declare -a DEVELS=(
                     "cuda_cudart_devel:cuda_cudart"
                     "cuda_driver_devel:cuda_cudart"
-                    "cuda_nvcc:cuda_nvcc"
                     "cuda_nvrtc_devel:cuda_nvrtc"
                     "libcublas_devel:libcublas"
                     "libcufft_devel:libcufft"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.11.0" %}
+{% set version = "4.11.1" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}


### PR DESCRIPTION
This reverts PR: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/356

We already are grabbing `nvcc` from the manifest and including it in the RPMs we will install on this line

https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/0e2048e39ef6bf91f04761f08b5510888a576567/recipe/cross_compile_support.sh#L113-L114

All adding it to `DEVELS` would have done is handle any remapping of the name in terms of manifest and package. However as the name is the same in both cases, this doesn't matter

IOW the aforementioned PR was effectively a no-op and what it was trying to accomplish had already been done. So while it causes no actual issues, it is probably best to clean this up to avoid confusion

This PR returns it to the prior state and bumps the patch version

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
