### PR TITLE
[rattler-build] Correctly propagate target platform to `host_{arch|platform}`

### DIFF
--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -62,8 +62,8 @@ def get_built_distribution_names_and_subdirs(recipe_dir=None, variant=None, buil
             if target_platform != "noarch":
                 platform, arch = target_platform.split("-")
                 extra_args = {
-                    "platform": platform,
-                    "arch": arch
+                    "host_platform": platform,
+                    "host_arch": arch
                 }
 
         config = conda_build.config.Config(**extra_args)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.11.1" %}
+{% set version = "4.11.2" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}


### PR DESCRIPTION
The target platform was wrongly propagated in the conda build Config object in `arch` and `platform` instead of `host_arch` and `host_platform`. 

Sister PR: https://github.com/prefix-dev/rattler-build-conda-compat/pull/59

I encountered the issue when converting a feedstock to rattler at https://github.com/conda-forge/xformers-feedstock/pull/33