### PR TITLE
Generally enable CUDA 12 cross-compilation

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -144,12 +144,9 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
         elif [[ "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then
             echo "cross compiling with cuda == 11.8 and cdt != cos7/8 not supported yet"
             exit 1
-        elif [[ "${CUDA_COMPILER_VERSION}" == 12* ]] && [[ "${CDT_NAME}" == "cos7" ]]; then
+        elif [[ "${CUDA_COMPILER_VERSION}" == 12* ]]; then
             # No extra steps necessary for CUDA 12, handled through new packages
             true
-        elif [[ "${CUDA_COMPILER_VERSION}" == 12* ]]; then
-            echo 'cross compiling with cuda == 12.* and cdt != cos7 not supported yet'
-            exit 1
         elif [[ "${CUDA_COMPILER_VERSION}" != "None" ]]; then
             echo 'cross compiling with cuda not in (11.2, 11.8, 12.*) not supported yet'
             exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.12.0" %}
+{% set version = "4.13.0" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}


### PR DESCRIPTION
As CUDA 12 uses standard conda-forge images and ships a CUDA Toolkit enabled for cross-compilation, there is no need to check for `CDT_NAME` in the CUDA 12 check. Any value conda-forge otherwise supports should also apply to CUDA 12.

CUDA 11 still requires special handling. Though this is not changed here.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
