### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\S'

### DIFF
--- a/recipe/conda_forge_ci_setup/build_utils.py
+++ b/recipe/conda_forge_ci_setup/build_utils.py
@@ -236,7 +236,7 @@ def upload_package(feedstock_root, recipe_root, config_file, validate, private, 
 
     upload_to_conda_forge = any(owner == "conda-forge" for owner, _ in channels)
     if upload_to_conda_forge and "channel_sources" in specific_config:
-        allowed_channels = ["conda-forge", "conda-forge/label/\S+"]
+        allowed_channels = ["conda-forge", r"conda-forge/label/\S+"]
         if feedstock_name in DEFAULTS_ALLOWED_FEEDSTOCKS:
             allowed_channels.append("defaults")
         for source_channel in source_channels.split(","):


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
