### PR TITLE
show qemu version when running cross_compile_support.sh

### DIFF
--- a/recipe/cross_compile_support.sh
+++ b/recipe/cross_compile_support.sh
@@ -49,6 +49,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
             echo "CROSSCOMPILING_EMULATOR: " >> ${CI_SUPPORT}/${CONFIG}.yaml
             echo "- /usr/bin/qemu-${HOST_PLATFORM_ARCH}-static"  >> ${CI_SUPPORT}/${CONFIG}.yaml
         fi
+        /usr/bin/qemu-${HOST_PLATFORM_ARCH}-static --version
 
 
         if [[ "${CUDA_COMPILER_VERSION}" == "11.2" || "${CUDA_COMPILER_VERSION}" == "11.8" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.14.2" %}
+{% set version = "4.14.3" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}


### PR DESCRIPTION
I'm running into a possible regression in QEMU (c.f. https://github.com/conda-forge/ctng-compilers-feedstock/pull/147), and I cannot go back to the last passing CI run to see which version was used. So ensure that the version gets logged.