### PR TITLE
Compare `CONDA_BLD_PATH` to drive for pagefile location

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.14.4" %}
+{% set version = "4.14.5" %}
 {% set build = 1 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -23,7 +23,7 @@ conda.exe config --set channel_priority %channel_priority%
 
 :: Set the conda-build working directory to a smaller path
 if "%CONDA_BLD_PATH%" == "" (
-    set "CONDA_BLD_PATH=C:\\bld\\"
+    set "CONDA_BLD_PATH=C:\bld"
 )
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
@@ -34,17 +34,21 @@ set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
 if "%SET_PAGEFILE%" NEQ "" (
     if "%CI%" == "azure" (
         REM use different drive than CONDA_BLD_PATH-location for pagefile
-        if "%CONDA_BLD_PATH%" == "C:\\bld\\" (
-            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 16GB on D:
-            REM Inspired by:
-            REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
-            REM Drive-letter needs to be escaped in quotes
-            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 16GB -DiskRoot \"D:\""
+        if "%CONDA_BLD_PATH:~0,2%" == "C:" (
+            set PAGEFILE_DRIVE="D:"
         )
-        if "%CONDA_BLD_PATH%" == "D:\\bld\\" (
-            echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 16GB on C:
-            PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 16GB -DiskRoot \"C:\""
+        else if "%CONDA_BLD_PATH:~0,2%" == "D:" (
+            set PAGEFILE_DRIVE="C:"
         )
+        else (
+            REM Default to the larger drive
+            set PAGEFILE_DRIVE="C:"
+        )
+        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 16GB on %PAGEFILE_DRIVE%
+        REM Inspired by:
+        REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
+        REM Drive-letter needs to be escaped in quotes
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 16GB -DiskRoot \"%PAGEFILE_DRIVE%""
     )
 )
 


### PR DESCRIPTION
* Compare first 2 characters of `CONDA_BLD_PATH` to drive (supports variations of the path better)
* Add a default case if `CONDA_BLD_PATH` drive detection fails for some reason
* Shorten `CONDA_BLD_PATH` a bit more

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
