### PR TITLE
fix: check that build dir is available before listing its content

### DIFF
--- a/recipe/conda_forge_ci_setup/utils.py
+++ b/recipe/conda_forge_ci_setup/utils.py
@@ -106,7 +106,10 @@ def built_distributions(subdirs=()):
         subdirs = context.subdir, "noarch"
     paths = []
     for subdir in subdirs:
-        for path in os.listdir(os.path.join(conda_build.config.croot, subdir)):
+        subdir_path = os.path.join(conda_build.config.croot, subdir)
+        if not subdir_path.is_dir():
+            continue
+        for path in os.listdir(subdir_path):
             if path.endswith((".tar.bz2", ".conda")):
                 paths.append(os.path.join(conda_build.config.croot, subdir, path))
     return paths


### PR DESCRIPTION
I ran into an error that perhaps is better avoided by this check if a directory exists.

It looked like this in the [logs from Azure's CI runners](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1221976&view=logs&j=fe7faf59-69bb-5487-b8fd-a35a7bda3a51&t=55731638-dd49-5144-2129-5101b9dd1960) - all outputs etc was skipped in this situation.

Maybe this PR isn't doing the best thing, and it could be better to error loudly with helpful guidance, I am not sure.


```
 │ Build variant: dask-gateway-server-2025.4.0-py313h6258d49_2 (skipped)
 │ 
 │ ╭─────────────────┬────────────────────╮
 │ │ Variant         ┆ Version            │
 │ ╞═════════════════╪════════════════════╡
 │ │ channel_targets ┆ "conda-forge main" │
 │ │ python          ┆ "3.13.* *_cp313"   │
 │ │ python_min      ┆ "3.10"             │
 │ │ target_platform ┆ "win-64"           │
 │ ╰─────────────────┴────────────────────╯
 │
 ╰─────────────────── (took 0 seconds)
Adding in variants from internal_defaults
Adding in variants from D:\a\1\s\recipe\variants.yaml
Adding in variants from argument_variants
Traceback (most recent call last):
  File "D:\Miniforge\Scripts\validate_recipe_outputs-script.py", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "D:\Miniforge\Lib\site-packages\click\core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "D:\Miniforge\Lib\site-packages\click\core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "D:\Miniforge\Lib\site-packages\click\core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Miniforge\Lib\site-packages\click\core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "D:\Miniforge\Lib\site-packages\conda_forge_ci_setup\feedstock_outputs.py", line 162, in main
    distributions = built_distributions_from_recipe_variant(recipe_dir=recipe_dir, variant=variant)
  File "D:\Miniforge\Lib\site-packages\conda_forge_ci_setup\utils.py", line 126, in built_distributions_from_recipe_variant
    for dist in built_distributions(subdirs=allowed_subdirs)
                ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Miniforge\Lib\site-packages\conda_forge_ci_setup\utils.py", line 109, in built_distributions
    for path in os.listdir(os.path.join(conda_build.config.croot, subdir)):
                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'D:\\bld\\win-64'

```