### PR TITLE
show `conda {info,config,list}` commands being called

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.21.0" %}
+{% set version = "4.21.1" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -150,6 +150,7 @@ echo - %CONDA_BUILD_SKIP_TESTS%                   >> ".ci_support\%CONFIG%.yaml"
 
 call activate base
 
+@echo on
 conda.exe info
 conda.exe config --show-sources
 conda.exe list --show-channel-urls


### PR DESCRIPTION
For debugging (or preparing bug reports to conda-build), it's convenient to be able to search for `conda info` in the logs. However, currently the ci-setup on windows only shows the output of those calls, but not the calls themselves (in contrast to unix).

Fix this.