### PR TITLE
 Delete clang(s) in windows runner images that get prioritized over our own compilers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.23.1" %}
+{% set version = "4.23.2" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -78,6 +78,18 @@ if defined CI (
     DEL C:\Windows\System32\msmpires.dll || (Echo Ignoring failure to delete C:\Windows\System32\msmpires.dll)
 )
 
+:: MSVC vendors clang, which gets picked up before our own compilers, so we delete it
+:: Additionally, the chocolatey-based installation of LLVM in the images may bring in yet another LLVM, c.f.
+:: https://github.com/actions/runner-images/blob/main/images/windows/scripts/build/Install-LLVM.ps1
+:: and the end of `chocolateyinstall.ps1` in https://community.chocolatey.org/packages/llvm/20.1.8#files
+if defined CI (
+    RMDIR /s /q "C:\Program Files\LLVM" || (Echo Ignoring failure to delete C:\Program Files\LLVM)
+    RMDIR /s /q "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm" ^
+        || (Echo Ignoring failure to delete C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm)
+    RMDIR /s /q "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Tools\Llvm" ^
+        || (Echo Ignoring failure to delete C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Tools\Llvm)
+)
+
 :: Make paths like C:\hostedtoolcache\windows\Ruby\2.5.7\x64\bin garbage
 set "PATH=%PATH:ostedtoolcache=%"
 set "PATH=%PATH:xternals\git\mingw=%"


### PR DESCRIPTION
The windows runner image started shipping clang binaries on a path that gets prioritized over compilers from `build:`. This leads to various work-arounds (not yet super-widespread because clang is not the default compiler on windows), for example
* [clangdev](https://github.com/conda-forge/clangdev-feedstock/blob/601374190c2b542ad59f6a5c4bb393d3869e64d0/recipe/meta.yaml#L499-L500)
* [openmp](https://github.com/conda-forge/openmp-feedstock/blob/5c874b6f5ee382950f0f64515f289096a48d8511/recipe/bld.bat#L13-L14)
* [cython-blis](https://github.com/conda-forge/cython-blis-feedstock/blob/dbdbecefb9684617918a3d885ba12fab8d1690d3/recipe/bld.bat#L3-L5)

There's probably several other feedstocks where this simply did not become obvious yet - absent some other constraints (e.g. cython-blis needs clang <19 and fails otherwise), this needs fairly close study of the logs to find that the wrong clang is used, which is of course a risk in the sense that we're suddenly building stuff with a toolchain whose configuration we don't control (for homogeneity of various flags, etc.).

Rather than leaving this footgun lying around, we should remove these vendored clangs in all our CI runs. If people want to use clang on windows, they should add it to the respective `build:` environment, as with everything else.

In addition to the clang vendored by MSVC, the runner images _also_ add LLVM [directly](https://github.com/actions/runner-images/blob/main/images/windows/scripts/build/Install-LLVM.ps1) from choco. We remove both variants here, including the respective path for the just-released VS2026, which will show up in the images quite soon.