### PR TITLE
set CONDA_OVERRIDE_CUDA_ARCH when cuda_arch_version is set in conda_forge_config.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-forge-ci-setup" %}
-{% set version = "4.25.1" %}
+{% set version = "4.26.0" %}
 {% set build = 0 %}
 
 {% set cuda_compiler_version = cuda_compiler_version or "None" %}

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -82,6 +82,13 @@ CUDA_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value cuda_compile
 if [[ "$CUDA_VERSION" != "None" ]]; then
     export CONDA_OVERRIDE_CUDA="${CUDA_VERSION}"
     echo "export CONDA_OVERRIDE_CUDA='${CONDA_OVERRIDE_CUDA}'" >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
+
+    # Export CONDA_OVERRIDE_CUDA_ARCH to allow __cuda_arch to report the arch on CI systems without GPUs
+    CUDA_ARCH_VERSION="$(cat ${CI_SUPPORT}/${CONFIG}.yaml | shyaml get-value cuda_arch_version.0 None)"
+    if [[ "$CUDA_ARCH_VERSION" != "None" ]]; then
+        export CONDA_OVERRIDE_CUDA_ARCH="${CUDA_ARCH_VERSION}"
+        echo "export CONDA_OVERRIDE_CUDA_ARCH='${CONDA_OVERRIDE_CUDA_ARCH}'" >> "${CONDA_PREFIX}/etc/conda/activate.d/conda-forge-ci-setup-activate.sh"
+    fi
 fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -108,6 +108,15 @@ if not "%CUDA_VERSION%" == "None" (
         set "PATH=%PATH%;%CUDA_PATH%\bin"
         set "CONDA_OVERRIDE_CUDA=%CUDA_VERSION%"
     )
+
+    :: Export CONDA_OVERRIDE_CUDA_ARCH to allow __cuda_arch to report the arch on CI systems without GPUs
+    cat .ci_support\%CONFIG%.yaml | shyaml get-value cuda_arch_version.0 None > cuda_arch.version
+    set /p CUDA_ARCH_VERSION=<cuda_arch.version
+    del cuda_arch.version
+    if not "%CUDA_ARCH_VERSION%" == "None" (
+        set "CONDA_OVERRIDE_CUDA_ARCH=%CUDA_ARCH_VERSION%"
+        echo set "CONDA_OVERRIDE_CUDA_ARCH=%CONDA_OVERRIDE_CUDA_ARCH%" >> "%CONDA_PREFIX%\etc\conda\activate.d\conda-forge-ci-setup-activate.bat"
+    )
 )
 :: /CUDA
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In this MR, conda-forge-ci-setup is extended to set `CONDA_OVERRIDE_CUDA_ARCH` in the CI similarly to how `CONDA_OVERRIDE_CUDA` is set.

This is needed in order to build packages which require `__cuda_arch`. Otherwise, during the test phase, the package being built will be uninstallable.